### PR TITLE
Fix: Correct interest calculation for special payments

### DIFF
--- a/src/pyloan/_enums.py
+++ b/src/pyloan/_enums.py
@@ -10,11 +10,8 @@ class LoanType(Enum):
     INTEREST_ONLY = 'interest-only'
 
 class CompoundingMethod(Enum):
-    THIRTY_A_360 = '30A/360'
-    THIRTY_U_360 = '30U/360'
-    THIRTY_E_360 = '30E/360'
+    THIRTY_360_US = '30/360 (US)'
     THIRTY_E_360_ISDA = '30E/360 ISDA'
-    ACTUAL_360 = 'A/360'
-    ACTUAL_365_FIXED = 'A/365F'
-    ACTUAL_ACTUAL_ISDA = 'A/A ISDA'
-    ACTUAL_ACTUAL_AFB = 'A/A AFB'
+    ACTUAL_365_FIXED = 'Actual/365 (Fixed)'
+    ACTUAL_360 = 'Actual/360'
+    ACTUAL_ACTUAL_ISDA = 'Actual/Actual (ISDA)'

--- a/src/pyloan/pyloan.py
+++ b/src/pyloan/pyloan.py
@@ -53,7 +53,7 @@ class Loan(object):
                  payment_end_of_month: bool = True,
                  annual_payments: int = 12,
                  interest_only_period: int = 0,
-                 compounding_method: str = CompoundingMethod.THIRTY_E_360.value,
+                 compounding_method: str = CompoundingMethod.THIRTY_E_360_ISDA.value,
                  loan_type: str = LoanType.ANNUITY.value) -> None:
         
         self._validate_inputs(loan_amount, interest_rate, loan_term, start_date, loan_term_period, payment_amount, first_payment_date, payment_end_of_month, annual_payments, interest_only_period, compounding_method, loan_type)
@@ -280,10 +280,37 @@ class Loan(object):
         )
         return [initial_payment]
 
+    def _calculate_interest_for_period(self, start_date, end_date, balance_at_start, special_payments_in_period):
+        """
+        Calculates the interest for a given period, considering special payments.
+        """
+        _, year = DAY_COUNT_METHODS[self.compounding_method.value](start_date, end_date)
+
+        period_event_dates = sorted([start_date] + list(special_payments_in_period.keys()))
+
+        interest_amount = Decimal('0')
+        running_balance = balance_at_start
+
+        for i in range(len(period_event_dates)):
+            start_sub = period_event_dates[i]
+            end_sub = period_event_dates[i+1] if i + 1 < len(period_event_dates) else end_date
+
+            days_sub_period_start, _ = DAY_COUNT_METHODS[self.compounding_method.value](start_date, start_sub)
+            days_sub_period_end, _ = DAY_COUNT_METHODS[self.compounding_method.value](start_date, end_sub)
+
+            days_in_sub = days_sub_period_end - days_sub_period_start
+
+            comp_factor = Decimal(str(days_in_sub / year))
+            interest_amount += self._quantize(running_balance * self.interest_rate * comp_factor)
+
+            if end_sub in special_payments_in_period:
+                running_balance -= special_payments_in_period[end_sub]
+
+        return interest_amount
+
     def get_payment_schedule(self) -> List[Payment]:
         """
         Calculates the payment schedule for the loan.
-
         :return: A list of Payment objects.
         """
         payment_schedule = self._initialize_payment_schedule()
@@ -297,7 +324,7 @@ class Loan(object):
         payment_timeline = self._get_payment_timeline(special_payments)
         regular_payment_dates = self._get_regular_payment_dates()
 
-        accrued_interest = Decimal('0')
+        all_regular_dates = [self.start_date] + regular_payment_dates
 
         for date in payment_timeline:
             last_payment = payment_schedule[-1]
@@ -306,56 +333,53 @@ class Loan(object):
             if balance_bop <= 0:
                 continue
 
-            bop_date = last_payment.date
-            compounding_factor = Decimal(str(DAY_COUNT_METHODS[self.compounding_method.value](bop_date, date, self.payment_end_of_month)[0] / DAY_COUNT_METHODS[self.compounding_method.value](bop_date, date, self.payment_end_of_month)[1]))
-            period_interest = self._quantize(balance_bop * self.interest_rate * compounding_factor)
-            accrued_interest += period_interest
-
-            is_regular_day = date in regular_payment_dates
-            is_special_day = date in special_payments
-
             interest_amount = Decimal('0')
             principal_amount = Decimal('0')
             special_principal_amount = Decimal('0')
 
-            if is_regular_day:
-                interest_amount = self._quantize(accrued_interest)
-                accrued_interest = Decimal('0')
+            if date in regular_payment_dates:
+                last_regular_date = next(d for d in reversed(all_regular_dates) if d < date)
+
+                special_payments_in_period = {
+                    p_date: p_amount for p_date, p_amount in special_payments.items() if last_regular_date < p_date < date
+                }
+
+                balance_at_period_start = next(p.loan_balance_amount for p in reversed(payment_schedule) if p.date == last_regular_date)
+
+                interest_amount = self._calculate_interest_for_period(last_regular_date, date, balance_at_period_start, special_payments_in_period)
 
                 if interest_only_payments_left <= 0:
                     if self.loan_type == LoanType.ANNUITY:
-                        principal_amount = min(self._quantize(regular_payment_amount) - interest_amount, balance_bop)
+                        principal_amount = min(regular_payment_amount - interest_amount, balance_bop)
                     else: # LINEAR
-                        principal_amount = min(self._quantize(regular_payment_amount), balance_bop)
-
+                        principal_amount = min(regular_payment_amount, balance_bop)
                 interest_only_payments_left -= 1
 
-            if is_special_day:
+            if date in special_payments:
                 special_principal_amount = min(balance_bop - principal_amount, special_payments[date])
 
-            total_principal_amount = min(principal_amount + special_principal_amount, balance_bop)
-            total_payment_amount = total_principal_amount + interest_amount
-            balance_eop = max(balance_bop - total_principal_amount, self._quantize(0))
+            total_principal_amount = self._quantize(principal_amount + special_principal_amount)
+            total_payment_amount = self._quantize(total_principal_amount + interest_amount)
+            balance_eop = self._quantize(balance_bop - total_principal_amount)
 
-            # The last payment amount should be the remaining balance + interest
-            if balance_eop == 0 and total_principal_amount < balance_bop:
-                total_principal_amount = balance_bop
-                total_payment_amount = total_principal_amount + interest_amount
-
+            if balance_eop < Decimal('0.01') and balance_eop > Decimal('0'):
+                total_principal_amount += balance_eop
+                total_payment_amount += balance_eop
+                balance_eop = Decimal('0')
 
             payment = Payment(
                 date=date,
                 payment_amount=total_payment_amount,
-                interest_amount=interest_amount,
-                principal_amount=principal_amount,
-                special_principal_amount=special_principal_amount,
+                interest_amount=self._quantize(interest_amount),
+                principal_amount=self._quantize(principal_amount),
+                special_principal_amount=self._quantize(special_principal_amount),
                 total_principal_amount=total_principal_amount,
                 loan_balance_amount=balance_eop
             )
-
             payment_schedule.append(payment)
 
         return payment_schedule
+
 
     def add_special_payment(self,
                             payment_amount: Union[int, float],

--- a/tests/scenarios.json
+++ b/tests/scenarios.json
@@ -61,7 +61,7 @@
       "payment_end_of_month": true,
       "annual_payments": 12,
       "interest_only_period": 0,
-      "compounding_method": "30E/360",
+      "compounding_method": "30E/360 ISDA",
       "loan_type": "annuity"
     },
     "special_payments": [

--- a/tests/snapshots/annuity_loan_term_in_months.json
+++ b/tests/snapshots/annuity_loan_term_in_months.json
@@ -13,7 +13,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "966.67",
     "principal_amount": "232.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "232.43",
     "loan_balance_amount": "199767.57"
   },
@@ -22,7 +22,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "932.25",
     "principal_amount": "266.85",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "266.85",
     "loan_balance_amount": "199500.72"
   },
@@ -31,7 +31,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1064.00",
     "principal_amount": "135.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "135.10",
     "loan_balance_amount": "199365.62"
   },
@@ -40,7 +40,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "996.83",
     "principal_amount": "202.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "202.27",
     "loan_balance_amount": "199163.35"
   },
@@ -49,7 +49,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "995.82",
     "principal_amount": "203.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "203.28",
     "loan_balance_amount": "198960.07"
   },
@@ -58,7 +58,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "994.80",
     "principal_amount": "204.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "204.30",
     "loan_balance_amount": "198755.77"
   },
@@ -67,7 +67,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "993.78",
     "principal_amount": "205.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "205.32",
     "loan_balance_amount": "198550.45"
   },
@@ -76,7 +76,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "992.75",
     "principal_amount": "206.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "206.35",
     "loan_balance_amount": "198344.10"
   },
@@ -85,7 +85,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "991.72",
     "principal_amount": "207.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "207.38",
     "loan_balance_amount": "198136.72"
   },
@@ -94,7 +94,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "990.68",
     "principal_amount": "208.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "208.42",
     "loan_balance_amount": "197928.30"
   },
@@ -103,7 +103,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "989.64",
     "principal_amount": "209.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "209.46",
     "loan_balance_amount": "197718.84"
   },
@@ -112,7 +112,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "988.59",
     "principal_amount": "210.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "210.51",
     "loan_balance_amount": "197508.33"
   },
@@ -121,7 +121,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "987.54",
     "principal_amount": "211.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "211.56",
     "loan_balance_amount": "197296.77"
   },
@@ -130,7 +130,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "920.72",
     "principal_amount": "278.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "278.38",
     "loan_balance_amount": "197018.39"
   },
@@ -139,7 +139,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1050.76",
     "principal_amount": "148.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "148.34",
     "loan_balance_amount": "196870.05"
   },
@@ -148,7 +148,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "984.35",
     "principal_amount": "214.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "214.75",
     "loan_balance_amount": "196655.30"
   },
@@ -157,7 +157,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "983.28",
     "principal_amount": "215.82",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "215.82",
     "loan_balance_amount": "196439.48"
   },
@@ -166,7 +166,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "982.20",
     "principal_amount": "216.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "216.90",
     "loan_balance_amount": "196222.58"
   },
@@ -175,7 +175,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "981.11",
     "principal_amount": "217.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "217.99",
     "loan_balance_amount": "196004.59"
   },
@@ -184,7 +184,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "980.02",
     "principal_amount": "219.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "219.08",
     "loan_balance_amount": "195785.51"
   },
@@ -193,7 +193,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "978.93",
     "principal_amount": "220.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "220.17",
     "loan_balance_amount": "195565.34"
   },
@@ -202,7 +202,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "977.83",
     "principal_amount": "221.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "221.27",
     "loan_balance_amount": "195344.07"
   },
@@ -211,7 +211,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "976.72",
     "principal_amount": "222.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "222.38",
     "loan_balance_amount": "195121.69"
   },
@@ -220,7 +220,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "975.61",
     "principal_amount": "223.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "223.49",
     "loan_balance_amount": "194898.20"
   },
@@ -229,7 +229,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "974.49",
     "principal_amount": "224.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "224.61",
     "loan_balance_amount": "194673.59"
   },
@@ -238,7 +238,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "940.92",
     "principal_amount": "258.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "258.18",
     "loan_balance_amount": "194415.41"
   },
@@ -247,7 +247,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1004.48",
     "principal_amount": "194.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "194.62",
     "loan_balance_amount": "194220.79"
   },
@@ -256,7 +256,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "971.10",
     "principal_amount": "228.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "228.00",
     "loan_balance_amount": "193992.79"
   },
@@ -265,7 +265,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "969.96",
     "principal_amount": "229.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "229.14",
     "loan_balance_amount": "193763.65"
   },
@@ -274,7 +274,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "968.82",
     "principal_amount": "230.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "230.28",
     "loan_balance_amount": "193533.37"
   },
@@ -283,7 +283,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "967.67",
     "principal_amount": "231.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "231.43",
     "loan_balance_amount": "193301.94"
   },
@@ -292,7 +292,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "966.51",
     "principal_amount": "232.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "232.59",
     "loan_balance_amount": "193069.35"
   },
@@ -301,7 +301,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "965.35",
     "principal_amount": "233.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "233.75",
     "loan_balance_amount": "192835.60"
   },
@@ -310,7 +310,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "964.18",
     "principal_amount": "234.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "234.92",
     "loan_balance_amount": "192600.68"
   },
@@ -319,7 +319,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "963.00",
     "principal_amount": "236.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "236.10",
     "loan_balance_amount": "192364.58"
   },
@@ -328,7 +328,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "961.82",
     "principal_amount": "237.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "237.28",
     "loan_balance_amount": "192127.30"
   },
@@ -337,7 +337,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "960.64",
     "principal_amount": "238.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "238.46",
     "loan_balance_amount": "191888.84"
   },
@@ -346,7 +346,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "895.48",
     "principal_amount": "303.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "303.62",
     "loan_balance_amount": "191585.22"
   },
@@ -355,7 +355,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1021.79",
     "principal_amount": "177.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "177.31",
     "loan_balance_amount": "191407.91"
   },
@@ -364,7 +364,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "957.04",
     "principal_amount": "242.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "242.06",
     "loan_balance_amount": "191165.85"
   },
@@ -373,7 +373,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "955.83",
     "principal_amount": "243.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "243.27",
     "loan_balance_amount": "190922.58"
   },
@@ -382,7 +382,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "954.61",
     "principal_amount": "244.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "244.49",
     "loan_balance_amount": "190678.09"
   },
@@ -391,7 +391,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "953.39",
     "principal_amount": "245.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "245.71",
     "loan_balance_amount": "190432.38"
   },
@@ -400,7 +400,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "952.16",
     "principal_amount": "246.94",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "246.94",
     "loan_balance_amount": "190185.44"
   },
@@ -409,7 +409,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "950.93",
     "principal_amount": "248.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "248.17",
     "loan_balance_amount": "189937.27"
   },
@@ -418,7 +418,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "949.69",
     "principal_amount": "249.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "249.41",
     "loan_balance_amount": "189687.86"
   },
@@ -427,7 +427,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "948.44",
     "principal_amount": "250.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "250.66",
     "loan_balance_amount": "189437.20"
   },
@@ -436,7 +436,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "947.19",
     "principal_amount": "251.91",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "251.91",
     "loan_balance_amount": "189185.29"
   },
@@ -445,7 +445,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "945.93",
     "principal_amount": "253.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "253.17",
     "loan_balance_amount": "188932.12"
   },
@@ -454,7 +454,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "881.68",
     "principal_amount": "317.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "317.42",
     "loan_balance_amount": "188614.70"
   },
@@ -463,7 +463,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1005.95",
     "principal_amount": "193.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "193.15",
     "loan_balance_amount": "188421.55"
   },
@@ -472,7 +472,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "942.11",
     "principal_amount": "256.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "256.99",
     "loan_balance_amount": "188164.56"
   },
@@ -481,7 +481,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "940.82",
     "principal_amount": "258.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "258.28",
     "loan_balance_amount": "187906.28"
   },
@@ -490,7 +490,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "939.53",
     "principal_amount": "259.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "259.57",
     "loan_balance_amount": "187646.71"
   },
@@ -499,7 +499,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "938.23",
     "principal_amount": "260.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "260.87",
     "loan_balance_amount": "187385.84"
   },
@@ -508,7 +508,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "936.93",
     "principal_amount": "262.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "262.17",
     "loan_balance_amount": "187123.67"
   },
@@ -517,7 +517,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "935.62",
     "principal_amount": "263.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "263.48",
     "loan_balance_amount": "186860.19"
   },
@@ -526,7 +526,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "934.30",
     "principal_amount": "264.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "264.80",
     "loan_balance_amount": "186595.39"
   },
@@ -535,7 +535,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "932.98",
     "principal_amount": "266.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "266.12",
     "loan_balance_amount": "186329.27"
   },
@@ -544,7 +544,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "931.65",
     "principal_amount": "267.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "267.45",
     "loan_balance_amount": "186061.82"
   },
@@ -553,7 +553,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "930.31",
     "principal_amount": "268.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "268.79",
     "loan_balance_amount": "185793.03"
   },
@@ -562,7 +562,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "867.03",
     "principal_amount": "332.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "332.07",
     "loan_balance_amount": "185460.96"
   },
@@ -571,7 +571,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "989.13",
     "principal_amount": "209.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "209.97",
     "loan_balance_amount": "185250.99"
   },
@@ -580,7 +580,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "926.25",
     "principal_amount": "272.85",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "272.85",
     "loan_balance_amount": "184978.14"
   },
@@ -589,7 +589,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "924.89",
     "principal_amount": "274.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "274.21",
     "loan_balance_amount": "184703.93"
   },
@@ -598,7 +598,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "923.52",
     "principal_amount": "275.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "275.58",
     "loan_balance_amount": "184428.35"
   },
@@ -607,7 +607,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "922.14",
     "principal_amount": "276.96",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "276.96",
     "loan_balance_amount": "184151.39"
   },
@@ -616,7 +616,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "920.76",
     "principal_amount": "278.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "278.34",
     "loan_balance_amount": "183873.05"
   },
@@ -625,7 +625,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "919.37",
     "principal_amount": "279.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "279.73",
     "loan_balance_amount": "183593.32"
   },
@@ -634,7 +634,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "917.97",
     "principal_amount": "281.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "281.13",
     "loan_balance_amount": "183312.19"
   },
@@ -643,7 +643,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "916.56",
     "principal_amount": "282.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "282.54",
     "loan_balance_amount": "183029.65"
   },
@@ -652,7 +652,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "915.15",
     "principal_amount": "283.95",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "283.95",
     "loan_balance_amount": "182745.70"
   },
@@ -661,7 +661,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "913.73",
     "principal_amount": "285.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "285.37",
     "loan_balance_amount": "182460.33"
   },
@@ -670,7 +670,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "881.89",
     "principal_amount": "317.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "317.21",
     "loan_balance_amount": "182143.12"
   },
@@ -679,7 +679,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "941.07",
     "principal_amount": "258.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "258.03",
     "loan_balance_amount": "181885.09"
   },
@@ -688,7 +688,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "909.43",
     "principal_amount": "289.67",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "289.67",
     "loan_balance_amount": "181595.42"
   },
@@ -697,7 +697,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "907.98",
     "principal_amount": "291.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "291.12",
     "loan_balance_amount": "181304.30"
   },
@@ -706,7 +706,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "906.52",
     "principal_amount": "292.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "292.58",
     "loan_balance_amount": "181011.72"
   },
@@ -715,7 +715,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "905.06",
     "principal_amount": "294.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "294.04",
     "loan_balance_amount": "180717.68"
   },
@@ -724,7 +724,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "903.59",
     "principal_amount": "295.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "295.51",
     "loan_balance_amount": "180422.17"
   },
@@ -733,7 +733,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "902.11",
     "principal_amount": "296.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "296.99",
     "loan_balance_amount": "180125.18"
   },
@@ -742,7 +742,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "900.63",
     "principal_amount": "298.47",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "298.47",
     "loan_balance_amount": "179826.71"
   },
@@ -751,7 +751,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "899.13",
     "principal_amount": "299.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "299.97",
     "loan_balance_amount": "179526.74"
   },
@@ -760,7 +760,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "897.63",
     "principal_amount": "301.47",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "301.47",
     "loan_balance_amount": "179225.27"
   },
@@ -769,7 +769,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "896.13",
     "principal_amount": "302.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "302.97",
     "loan_balance_amount": "178922.30"
   },
@@ -778,7 +778,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "834.97",
     "principal_amount": "364.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "364.13",
     "loan_balance_amount": "178558.17"
   },
@@ -787,7 +787,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "952.31",
     "principal_amount": "246.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "246.79",
     "loan_balance_amount": "178311.38"
   },
@@ -796,7 +796,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "891.56",
     "principal_amount": "307.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "307.54",
     "loan_balance_amount": "178003.84"
   },
@@ -805,7 +805,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "890.02",
     "principal_amount": "309.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "309.08",
     "loan_balance_amount": "177694.76"
   },
@@ -814,7 +814,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "888.47",
     "principal_amount": "310.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "310.63",
     "loan_balance_amount": "177384.13"
   },
@@ -823,7 +823,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "886.92",
     "principal_amount": "312.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "312.18",
     "loan_balance_amount": "177071.95"
   },
@@ -832,7 +832,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "885.36",
     "principal_amount": "313.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "313.74",
     "loan_balance_amount": "176758.21"
   },
@@ -841,7 +841,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "883.79",
     "principal_amount": "315.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "315.31",
     "loan_balance_amount": "176442.90"
   },
@@ -850,7 +850,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "882.21",
     "principal_amount": "316.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "316.89",
     "loan_balance_amount": "176126.01"
   },
@@ -859,7 +859,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "880.63",
     "principal_amount": "318.47",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "318.47",
     "loan_balance_amount": "175807.54"
   },
@@ -868,7 +868,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "879.04",
     "principal_amount": "320.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "320.06",
     "loan_balance_amount": "175487.48"
   },
@@ -877,7 +877,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "877.44",
     "principal_amount": "321.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "321.66",
     "loan_balance_amount": "175165.82"
   },
@@ -886,7 +886,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "817.44",
     "principal_amount": "381.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "381.66",
     "loan_balance_amount": "174784.16"
   },
@@ -895,7 +895,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "932.18",
     "principal_amount": "266.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "266.92",
     "loan_balance_amount": "174517.24"
   },
@@ -904,7 +904,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "872.59",
     "principal_amount": "326.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "326.51",
     "loan_balance_amount": "174190.73"
   },
@@ -913,7 +913,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "870.95",
     "principal_amount": "328.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "328.15",
     "loan_balance_amount": "173862.58"
   },
@@ -922,7 +922,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "869.31",
     "principal_amount": "329.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "329.79",
     "loan_balance_amount": "173532.79"
   },
@@ -931,7 +931,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "867.66",
     "principal_amount": "331.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "331.44",
     "loan_balance_amount": "173201.35"
   },
@@ -940,7 +940,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "866.01",
     "principal_amount": "333.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "333.09",
     "loan_balance_amount": "172868.26"
   },
@@ -949,7 +949,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "864.34",
     "principal_amount": "334.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "334.76",
     "loan_balance_amount": "172533.50"
   },
@@ -958,7 +958,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "862.67",
     "principal_amount": "336.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "336.43",
     "loan_balance_amount": "172197.07"
   },
@@ -967,7 +967,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "860.99",
     "principal_amount": "338.11",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "338.11",
     "loan_balance_amount": "171858.96"
   },
@@ -976,7 +976,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "859.29",
     "principal_amount": "339.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "339.81",
     "loan_balance_amount": "171519.15"
   },
@@ -985,7 +985,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "857.60",
     "principal_amount": "341.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "341.50",
     "loan_balance_amount": "171177.65"
   },
@@ -994,7 +994,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "798.83",
     "principal_amount": "400.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "400.27",
     "loan_balance_amount": "170777.38"
   },
@@ -1003,7 +1003,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "910.81",
     "principal_amount": "288.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "288.29",
     "loan_balance_amount": "170489.09"
   },
@@ -1012,7 +1012,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "852.45",
     "principal_amount": "346.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "346.65",
     "loan_balance_amount": "170142.44"
   },
@@ -1021,7 +1021,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "850.71",
     "principal_amount": "348.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "348.39",
     "loan_balance_amount": "169794.05"
   },
@@ -1030,7 +1030,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "848.97",
     "principal_amount": "350.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "350.13",
     "loan_balance_amount": "169443.92"
   },
@@ -1039,7 +1039,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "847.22",
     "principal_amount": "351.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "351.88",
     "loan_balance_amount": "169092.04"
   },
@@ -1048,7 +1048,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "845.46",
     "principal_amount": "353.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "353.64",
     "loan_balance_amount": "168738.40"
   },
@@ -1057,7 +1057,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "843.69",
     "principal_amount": "355.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "355.41",
     "loan_balance_amount": "168382.99"
   },
@@ -1066,7 +1066,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "841.91",
     "principal_amount": "357.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "357.19",
     "loan_balance_amount": "168025.80"
   },
@@ -1075,7 +1075,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "840.13",
     "principal_amount": "358.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "358.97",
     "loan_balance_amount": "167666.83"
   },
@@ -1084,7 +1084,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "838.33",
     "principal_amount": "360.77",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "360.77",
     "loan_balance_amount": "167306.06"
   },
@@ -1093,7 +1093,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "836.53",
     "principal_amount": "362.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "362.57",
     "loan_balance_amount": "166943.49"
   },
@@ -1102,7 +1102,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "806.89",
     "principal_amount": "392.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "392.21",
     "loan_balance_amount": "166551.28"
   },
@@ -1111,7 +1111,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "860.51",
     "principal_amount": "338.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "338.59",
     "loan_balance_amount": "166212.69"
   },
@@ -1120,7 +1120,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "831.06",
     "principal_amount": "368.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "368.04",
     "loan_balance_amount": "165844.65"
   },
@@ -1129,7 +1129,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "829.22",
     "principal_amount": "369.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "369.88",
     "loan_balance_amount": "165474.77"
   },
@@ -1138,7 +1138,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "827.37",
     "principal_amount": "371.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "371.73",
     "loan_balance_amount": "165103.04"
   },
@@ -1147,7 +1147,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "825.52",
     "principal_amount": "373.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "373.58",
     "loan_balance_amount": "164729.46"
   },
@@ -1156,7 +1156,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "823.65",
     "principal_amount": "375.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "375.45",
     "loan_balance_amount": "164354.01"
   },
@@ -1165,7 +1165,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "821.77",
     "principal_amount": "377.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "377.33",
     "loan_balance_amount": "163976.68"
   },
@@ -1174,7 +1174,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "819.88",
     "principal_amount": "379.22",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "379.22",
     "loan_balance_amount": "163597.46"
   },
@@ -1183,7 +1183,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "817.99",
     "principal_amount": "381.11",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "381.11",
     "loan_balance_amount": "163216.35"
   },
@@ -1192,7 +1192,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "816.08",
     "principal_amount": "383.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "383.02",
     "loan_balance_amount": "162833.33"
   },
@@ -1201,7 +1201,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "814.17",
     "principal_amount": "384.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "384.93",
     "loan_balance_amount": "162448.40"
   },
@@ -1210,7 +1210,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "758.09",
     "principal_amount": "441.01",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "441.01",
     "loan_balance_amount": "162007.39"
   },
@@ -1219,7 +1219,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "864.04",
     "principal_amount": "335.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "335.06",
     "loan_balance_amount": "161672.33"
   },
@@ -1228,7 +1228,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "808.36",
     "principal_amount": "390.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "390.74",
     "loan_balance_amount": "161281.59"
   },
@@ -1237,7 +1237,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "806.41",
     "principal_amount": "392.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "392.69",
     "loan_balance_amount": "160888.90"
   },
@@ -1246,7 +1246,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "804.44",
     "principal_amount": "394.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "394.66",
     "loan_balance_amount": "160494.24"
   },
@@ -1255,7 +1255,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "802.47",
     "principal_amount": "396.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "396.63",
     "loan_balance_amount": "160097.61"
   },
@@ -1264,7 +1264,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "800.49",
     "principal_amount": "398.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "398.61",
     "loan_balance_amount": "159699.00"
   },
@@ -1273,7 +1273,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "798.49",
     "principal_amount": "400.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "400.61",
     "loan_balance_amount": "159298.39"
   },
@@ -1282,7 +1282,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "796.49",
     "principal_amount": "402.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "402.61",
     "loan_balance_amount": "158895.78"
   },
@@ -1291,7 +1291,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "794.48",
     "principal_amount": "404.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "404.62",
     "loan_balance_amount": "158491.16"
   },
@@ -1300,7 +1300,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "792.46",
     "principal_amount": "406.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "406.64",
     "loan_balance_amount": "158084.52"
   },
@@ -1309,7 +1309,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "790.42",
     "principal_amount": "408.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "408.68",
     "loan_balance_amount": "157675.84"
   },
@@ -1318,7 +1318,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "735.82",
     "principal_amount": "463.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "463.28",
     "loan_balance_amount": "157212.56"
   },
@@ -1327,7 +1327,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "838.47",
     "principal_amount": "360.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "360.63",
     "loan_balance_amount": "156851.93"
   },
@@ -1336,7 +1336,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "784.26",
     "principal_amount": "414.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "414.84",
     "loan_balance_amount": "156437.09"
   },
@@ -1345,7 +1345,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "782.19",
     "principal_amount": "416.91",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "416.91",
     "loan_balance_amount": "156020.18"
   },
@@ -1354,7 +1354,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "780.10",
     "principal_amount": "419.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "419.00",
     "loan_balance_amount": "155601.18"
   },
@@ -1363,7 +1363,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "778.01",
     "principal_amount": "421.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "421.09",
     "loan_balance_amount": "155180.09"
   },
@@ -1372,7 +1372,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "775.90",
     "principal_amount": "423.20",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "423.20",
     "loan_balance_amount": "154756.89"
   },
@@ -1381,7 +1381,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "773.78",
     "principal_amount": "425.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "425.32",
     "loan_balance_amount": "154331.57"
   },
@@ -1390,7 +1390,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "771.66",
     "principal_amount": "427.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "427.44",
     "loan_balance_amount": "153904.13"
   },
@@ -1399,7 +1399,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "769.52",
     "principal_amount": "429.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "429.58",
     "loan_balance_amount": "153474.55"
   },
@@ -1408,7 +1408,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "767.37",
     "principal_amount": "431.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "431.73",
     "loan_balance_amount": "153042.82"
   },
@@ -1417,7 +1417,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "765.21",
     "principal_amount": "433.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "433.89",
     "loan_balance_amount": "152608.93"
   },
@@ -1426,7 +1426,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "712.18",
     "principal_amount": "486.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "486.92",
     "loan_balance_amount": "152122.01"
   },
@@ -1435,7 +1435,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "811.32",
     "principal_amount": "387.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "387.78",
     "loan_balance_amount": "151734.23"
   },
@@ -1444,7 +1444,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "758.67",
     "principal_amount": "440.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "440.43",
     "loan_balance_amount": "151293.80"
   },
@@ -1453,7 +1453,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "756.47",
     "principal_amount": "442.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "442.63",
     "loan_balance_amount": "150851.17"
   },
@@ -1462,7 +1462,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "754.26",
     "principal_amount": "444.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "444.84",
     "loan_balance_amount": "150406.33"
   },
@@ -1471,7 +1471,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "752.03",
     "principal_amount": "447.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "447.07",
     "loan_balance_amount": "149959.26"
   },
@@ -1480,7 +1480,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "749.80",
     "principal_amount": "449.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "449.30",
     "loan_balance_amount": "149509.96"
   },
@@ -1489,7 +1489,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "747.55",
     "principal_amount": "451.55",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "451.55",
     "loan_balance_amount": "149058.41"
   },
@@ -1498,7 +1498,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "745.29",
     "principal_amount": "453.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "453.81",
     "loan_balance_amount": "148604.60"
   },
@@ -1507,7 +1507,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "743.02",
     "principal_amount": "456.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "456.08",
     "loan_balance_amount": "148148.52"
   },
@@ -1516,7 +1516,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "740.74",
     "principal_amount": "458.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "458.36",
     "loan_balance_amount": "147690.16"
   },
@@ -1525,7 +1525,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "738.45",
     "principal_amount": "460.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "460.65",
     "loan_balance_amount": "147229.51"
   },
@@ -1534,7 +1534,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "711.61",
     "principal_amount": "487.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "487.49",
     "loan_balance_amount": "146742.02"
   },
@@ -1543,7 +1543,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "758.17",
     "principal_amount": "440.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "440.93",
     "loan_balance_amount": "146301.09"
   },
@@ -1552,7 +1552,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "731.51",
     "principal_amount": "467.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "467.59",
     "loan_balance_amount": "145833.50"
   },
@@ -1561,7 +1561,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "729.17",
     "principal_amount": "469.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "469.93",
     "loan_balance_amount": "145363.57"
   },
@@ -1570,7 +1570,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "726.82",
     "principal_amount": "472.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "472.28",
     "loan_balance_amount": "144891.29"
   },
@@ -1579,7 +1579,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "724.46",
     "principal_amount": "474.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "474.64",
     "loan_balance_amount": "144416.65"
   },
@@ -1588,7 +1588,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "722.08",
     "principal_amount": "477.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "477.02",
     "loan_balance_amount": "143939.63"
   },
@@ -1597,7 +1597,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "719.70",
     "principal_amount": "479.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "479.40",
     "loan_balance_amount": "143460.23"
   },
@@ -1606,7 +1606,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "717.30",
     "principal_amount": "481.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "481.80",
     "loan_balance_amount": "142978.43"
   },
@@ -1615,7 +1615,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "714.89",
     "principal_amount": "484.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "484.21",
     "loan_balance_amount": "142494.22"
   },
@@ -1624,7 +1624,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "712.47",
     "principal_amount": "486.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "486.63",
     "loan_balance_amount": "142007.59"
   },
@@ -1633,7 +1633,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "710.04",
     "principal_amount": "489.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "489.06",
     "loan_balance_amount": "141518.53"
   },
@@ -1642,7 +1642,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "660.42",
     "principal_amount": "538.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "538.68",
     "loan_balance_amount": "140979.85"
   },
@@ -1651,7 +1651,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "751.89",
     "principal_amount": "447.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "447.21",
     "loan_balance_amount": "140532.64"
   },
@@ -1660,7 +1660,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "702.66",
     "principal_amount": "496.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "496.44",
     "loan_balance_amount": "140036.20"
   },
@@ -1669,7 +1669,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "700.18",
     "principal_amount": "498.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "498.92",
     "loan_balance_amount": "139537.28"
   },
@@ -1678,7 +1678,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "697.69",
     "principal_amount": "501.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "501.41",
     "loan_balance_amount": "139035.87"
   },
@@ -1687,7 +1687,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "695.18",
     "principal_amount": "503.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "503.92",
     "loan_balance_amount": "138531.95"
   },
@@ -1696,7 +1696,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "692.66",
     "principal_amount": "506.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "506.44",
     "loan_balance_amount": "138025.51"
   },
@@ -1705,7 +1705,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "690.13",
     "principal_amount": "508.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "508.97",
     "loan_balance_amount": "137516.54"
   },
@@ -1714,7 +1714,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "687.58",
     "principal_amount": "511.52",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "511.52",
     "loan_balance_amount": "137005.02"
   },
@@ -1723,7 +1723,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "685.03",
     "principal_amount": "514.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "514.07",
     "loan_balance_amount": "136490.95"
   },
@@ -1732,7 +1732,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "682.45",
     "principal_amount": "516.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "516.65",
     "loan_balance_amount": "135974.30"
   },
@@ -1741,7 +1741,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "679.87",
     "principal_amount": "519.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "519.23",
     "loan_balance_amount": "135455.07"
   },
@@ -1750,7 +1750,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "632.12",
     "principal_amount": "566.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "566.98",
     "loan_balance_amount": "134888.09"
   },
@@ -1759,7 +1759,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "719.40",
     "principal_amount": "479.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "479.70",
     "loan_balance_amount": "134408.39"
   },
@@ -1768,7 +1768,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "672.04",
     "principal_amount": "527.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "527.06",
     "loan_balance_amount": "133881.33"
   },
@@ -1777,7 +1777,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "669.41",
     "principal_amount": "529.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "529.69",
     "loan_balance_amount": "133351.64"
   },
@@ -1786,7 +1786,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "666.76",
     "principal_amount": "532.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "532.34",
     "loan_balance_amount": "132819.30"
   },
@@ -1795,7 +1795,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "664.10",
     "principal_amount": "535.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "535.00",
     "loan_balance_amount": "132284.30"
   },
@@ -1804,7 +1804,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "661.42",
     "principal_amount": "537.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "537.68",
     "loan_balance_amount": "131746.62"
   },
@@ -1813,7 +1813,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "658.73",
     "principal_amount": "540.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "540.37",
     "loan_balance_amount": "131206.25"
   },
@@ -1822,7 +1822,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "656.03",
     "principal_amount": "543.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "543.07",
     "loan_balance_amount": "130663.18"
   },
@@ -1831,7 +1831,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "653.32",
     "principal_amount": "545.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "545.78",
     "loan_balance_amount": "130117.40"
   },
@@ -1840,7 +1840,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "650.59",
     "principal_amount": "548.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "548.51",
     "loan_balance_amount": "129568.89"
   },
@@ -1849,7 +1849,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "647.84",
     "principal_amount": "551.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "551.26",
     "loan_balance_amount": "129017.63"
   },
@@ -1858,7 +1858,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "602.08",
     "principal_amount": "597.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "597.02",
     "loan_balance_amount": "128420.61"
   },
@@ -1867,7 +1867,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "684.91",
     "principal_amount": "514.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "514.19",
     "loan_balance_amount": "127906.42"
   },
@@ -1876,7 +1876,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "639.53",
     "principal_amount": "559.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "559.57",
     "loan_balance_amount": "127346.85"
   },
@@ -1885,7 +1885,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "636.73",
     "principal_amount": "562.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "562.37",
     "loan_balance_amount": "126784.48"
   },
@@ -1894,7 +1894,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "633.92",
     "principal_amount": "565.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "565.18",
     "loan_balance_amount": "126219.30"
   },
@@ -1903,7 +1903,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "631.10",
     "principal_amount": "568.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "568.00",
     "loan_balance_amount": "125651.30"
   },
@@ -1912,7 +1912,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "628.26",
     "principal_amount": "570.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "570.84",
     "loan_balance_amount": "125080.46"
   },
@@ -1921,7 +1921,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "625.40",
     "principal_amount": "573.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "573.70",
     "loan_balance_amount": "124506.76"
   },
@@ -1930,7 +1930,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "622.53",
     "principal_amount": "576.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "576.57",
     "loan_balance_amount": "123930.19"
   },
@@ -1939,7 +1939,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "619.65",
     "principal_amount": "579.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "579.45",
     "loan_balance_amount": "123350.74"
   },
@@ -1948,7 +1948,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "616.75",
     "principal_amount": "582.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "582.35",
     "loan_balance_amount": "122768.39"
   },
@@ -1957,7 +1957,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "613.84",
     "principal_amount": "585.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "585.26",
     "loan_balance_amount": "122183.13"
   },
@@ -1966,7 +1966,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "590.55",
     "principal_amount": "608.55",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "608.55",
     "loan_balance_amount": "121574.58"
   },
@@ -1975,7 +1975,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "628.14",
     "principal_amount": "570.96",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "570.96",
     "loan_balance_amount": "121003.62"
   },
@@ -1984,7 +1984,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "605.02",
     "principal_amount": "594.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "594.08",
     "loan_balance_amount": "120409.54"
   },
@@ -1993,7 +1993,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "602.05",
     "principal_amount": "597.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "597.05",
     "loan_balance_amount": "119812.49"
   },
@@ -2002,7 +2002,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "599.06",
     "principal_amount": "600.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "600.04",
     "loan_balance_amount": "119212.45"
   },
@@ -2011,7 +2011,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "596.06",
     "principal_amount": "603.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "603.04",
     "loan_balance_amount": "118609.41"
   },
@@ -2020,7 +2020,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "593.05",
     "principal_amount": "606.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "606.05",
     "loan_balance_amount": "118003.36"
   },
@@ -2029,7 +2029,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "590.02",
     "principal_amount": "609.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "609.08",
     "loan_balance_amount": "117394.28"
   },
@@ -2038,7 +2038,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "586.97",
     "principal_amount": "612.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "612.13",
     "loan_balance_amount": "116782.15"
   },
@@ -2047,7 +2047,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "583.91",
     "principal_amount": "615.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "615.19",
     "loan_balance_amount": "116166.96"
   },
@@ -2056,7 +2056,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "580.83",
     "principal_amount": "618.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "618.27",
     "loan_balance_amount": "115548.69"
   },
@@ -2065,7 +2065,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "577.74",
     "principal_amount": "621.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "621.36",
     "loan_balance_amount": "114927.33"
   },
@@ -2074,7 +2074,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "536.33",
     "principal_amount": "662.77",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "662.77",
     "loan_balance_amount": "114264.56"
   },
@@ -2083,7 +2083,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "609.41",
     "principal_amount": "589.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "589.69",
     "loan_balance_amount": "113674.87"
   },
@@ -2092,7 +2092,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "568.37",
     "principal_amount": "630.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "630.73",
     "loan_balance_amount": "113044.14"
   },
@@ -2101,7 +2101,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "565.22",
     "principal_amount": "633.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "633.88",
     "loan_balance_amount": "112410.26"
   },
@@ -2110,7 +2110,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "562.05",
     "principal_amount": "637.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "637.05",
     "loan_balance_amount": "111773.21"
   },
@@ -2119,7 +2119,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "558.87",
     "principal_amount": "640.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "640.23",
     "loan_balance_amount": "111132.98"
   },
@@ -2128,7 +2128,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "555.66",
     "principal_amount": "643.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "643.44",
     "loan_balance_amount": "110489.54"
   },
@@ -2137,7 +2137,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "552.45",
     "principal_amount": "646.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "646.65",
     "loan_balance_amount": "109842.89"
   },
@@ -2146,7 +2146,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "549.21",
     "principal_amount": "649.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "649.89",
     "loan_balance_amount": "109193.00"
   },
@@ -2155,7 +2155,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "545.96",
     "principal_amount": "653.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "653.14",
     "loan_balance_amount": "108539.86"
   },
@@ -2164,7 +2164,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "542.70",
     "principal_amount": "656.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "656.40",
     "loan_balance_amount": "107883.46"
   },
@@ -2173,7 +2173,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "539.42",
     "principal_amount": "659.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "659.68",
     "loan_balance_amount": "107223.78"
   },
@@ -2182,7 +2182,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "500.38",
     "principal_amount": "698.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "698.72",
     "loan_balance_amount": "106525.06"
   },
@@ -2191,7 +2191,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "568.13",
     "principal_amount": "630.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "630.97",
     "loan_balance_amount": "105894.09"
   },
@@ -2200,7 +2200,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "529.47",
     "principal_amount": "669.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "669.63",
     "loan_balance_amount": "105224.46"
   },
@@ -2209,7 +2209,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "526.12",
     "principal_amount": "672.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "672.98",
     "loan_balance_amount": "104551.48"
   },
@@ -2218,7 +2218,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "522.76",
     "principal_amount": "676.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "676.34",
     "loan_balance_amount": "103875.14"
   },
@@ -2227,7 +2227,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "519.38",
     "principal_amount": "679.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "679.72",
     "loan_balance_amount": "103195.42"
   },
@@ -2236,7 +2236,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "515.98",
     "principal_amount": "683.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "683.12",
     "loan_balance_amount": "102512.30"
   },
@@ -2245,7 +2245,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "512.56",
     "principal_amount": "686.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "686.54",
     "loan_balance_amount": "101825.76"
   },
@@ -2254,7 +2254,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "509.13",
     "principal_amount": "689.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "689.97",
     "loan_balance_amount": "101135.79"
   },
@@ -2263,7 +2263,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "505.68",
     "principal_amount": "693.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "693.42",
     "loan_balance_amount": "100442.37"
   },
@@ -2272,7 +2272,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "502.21",
     "principal_amount": "696.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "696.89",
     "loan_balance_amount": "99745.48"
   },
@@ -2281,7 +2281,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "498.73",
     "principal_amount": "700.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "700.37",
     "loan_balance_amount": "99045.11"
   },
@@ -2290,7 +2290,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "462.21",
     "principal_amount": "736.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "736.89",
     "loan_balance_amount": "98308.22"
   },
@@ -2299,7 +2299,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "524.31",
     "principal_amount": "674.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "674.79",
     "loan_balance_amount": "97633.43"
   },
@@ -2308,7 +2308,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "488.17",
     "principal_amount": "710.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "710.93",
     "loan_balance_amount": "96922.50"
   },
@@ -2317,7 +2317,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "484.61",
     "principal_amount": "714.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "714.49",
     "loan_balance_amount": "96208.01"
   },
@@ -2326,7 +2326,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "481.04",
     "principal_amount": "718.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "718.06",
     "loan_balance_amount": "95489.95"
   },
@@ -2335,7 +2335,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "477.45",
     "principal_amount": "721.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "721.65",
     "loan_balance_amount": "94768.30"
   },
@@ -2344,7 +2344,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "473.84",
     "principal_amount": "725.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "725.26",
     "loan_balance_amount": "94043.04"
   },
@@ -2353,7 +2353,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "470.22",
     "principal_amount": "728.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "728.88",
     "loan_balance_amount": "93314.16"
   },
@@ -2362,7 +2362,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "466.57",
     "principal_amount": "732.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "732.53",
     "loan_balance_amount": "92581.63"
   },
@@ -2371,7 +2371,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "462.91",
     "principal_amount": "736.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "736.19",
     "loan_balance_amount": "91845.44"
   },
@@ -2380,7 +2380,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "459.23",
     "principal_amount": "739.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "739.87",
     "loan_balance_amount": "91105.57"
   },
@@ -2389,7 +2389,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "455.53",
     "principal_amount": "743.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "743.57",
     "loan_balance_amount": "90362.00"
   },
@@ -2398,7 +2398,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "436.75",
     "principal_amount": "762.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "762.35",
     "loan_balance_amount": "89599.65"
   },
@@ -2407,7 +2407,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "462.93",
     "principal_amount": "736.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "736.17",
     "loan_balance_amount": "88863.48"
   },
@@ -2416,7 +2416,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "444.32",
     "principal_amount": "754.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "754.78",
     "loan_balance_amount": "88108.70"
   },
@@ -2425,7 +2425,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "440.54",
     "principal_amount": "758.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "758.56",
     "loan_balance_amount": "87350.14"
   },
@@ -2434,7 +2434,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "436.75",
     "principal_amount": "762.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "762.35",
     "loan_balance_amount": "86587.79"
   },
@@ -2443,7 +2443,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "432.94",
     "principal_amount": "766.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "766.16",
     "loan_balance_amount": "85821.63"
   },
@@ -2452,7 +2452,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "429.11",
     "principal_amount": "769.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "769.99",
     "loan_balance_amount": "85051.64"
   },
@@ -2461,7 +2461,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "425.26",
     "principal_amount": "773.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "773.84",
     "loan_balance_amount": "84277.80"
   },
@@ -2470,7 +2470,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "421.39",
     "principal_amount": "777.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "777.71",
     "loan_balance_amount": "83500.09"
   },
@@ -2479,7 +2479,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "417.50",
     "principal_amount": "781.60",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "781.60",
     "loan_balance_amount": "82718.49"
   },
@@ -2488,7 +2488,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "413.59",
     "principal_amount": "785.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "785.51",
     "loan_balance_amount": "81932.98"
   },
@@ -2497,7 +2497,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "409.66",
     "principal_amount": "789.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "789.44",
     "loan_balance_amount": "81143.54"
   },
@@ -2506,7 +2506,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "378.67",
     "principal_amount": "820.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "820.43",
     "loan_balance_amount": "80323.11"
   },
@@ -2515,7 +2515,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "428.39",
     "principal_amount": "770.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "770.71",
     "loan_balance_amount": "79552.40"
   },
@@ -2524,7 +2524,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "397.76",
     "principal_amount": "801.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "801.34",
     "loan_balance_amount": "78751.06"
   },
@@ -2533,7 +2533,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "393.76",
     "principal_amount": "805.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "805.34",
     "loan_balance_amount": "77945.72"
   },
@@ -2542,7 +2542,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "389.73",
     "principal_amount": "809.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "809.37",
     "loan_balance_amount": "77136.35"
   },
@@ -2551,7 +2551,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "385.68",
     "principal_amount": "813.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "813.42",
     "loan_balance_amount": "76322.93"
   },
@@ -2560,7 +2560,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "381.61",
     "principal_amount": "817.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "817.49",
     "loan_balance_amount": "75505.44"
   },
@@ -2569,7 +2569,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "377.53",
     "principal_amount": "821.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "821.57",
     "loan_balance_amount": "74683.87"
   },
@@ -2578,7 +2578,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "373.42",
     "principal_amount": "825.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "825.68",
     "loan_balance_amount": "73858.19"
   },
@@ -2587,7 +2587,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "369.29",
     "principal_amount": "829.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "829.81",
     "loan_balance_amount": "73028.38"
   },
@@ -2596,7 +2596,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "365.14",
     "principal_amount": "833.96",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "833.96",
     "loan_balance_amount": "72194.42"
   },
@@ -2605,7 +2605,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "360.97",
     "principal_amount": "838.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "838.13",
     "loan_balance_amount": "71356.29"
   },
@@ -2614,7 +2614,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "333.00",
     "principal_amount": "866.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "866.10",
     "loan_balance_amount": "70490.19"
   },
@@ -2623,7 +2623,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "375.95",
     "principal_amount": "823.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "823.15",
     "loan_balance_amount": "69667.04"
   },
@@ -2632,7 +2632,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "348.34",
     "principal_amount": "850.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "850.76",
     "loan_balance_amount": "68816.28"
   },
@@ -2641,7 +2641,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "344.08",
     "principal_amount": "855.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "855.02",
     "loan_balance_amount": "67961.26"
   },
@@ -2650,7 +2650,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "339.81",
     "principal_amount": "859.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "859.29",
     "loan_balance_amount": "67101.97"
   },
@@ -2659,7 +2659,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "335.51",
     "principal_amount": "863.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "863.59",
     "loan_balance_amount": "66238.38"
   },
@@ -2668,7 +2668,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "331.19",
     "principal_amount": "867.91",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "867.91",
     "loan_balance_amount": "65370.47"
   },
@@ -2677,7 +2677,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "326.85",
     "principal_amount": "872.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "872.25",
     "loan_balance_amount": "64498.22"
   },
@@ -2686,7 +2686,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "322.49",
     "principal_amount": "876.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "876.61",
     "loan_balance_amount": "63621.61"
   },
@@ -2695,7 +2695,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "318.11",
     "principal_amount": "880.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "880.99",
     "loan_balance_amount": "62740.62"
   },
@@ -2704,7 +2704,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "313.70",
     "principal_amount": "885.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "885.40",
     "loan_balance_amount": "61855.22"
   },
@@ -2713,7 +2713,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "309.28",
     "principal_amount": "889.82",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "889.82",
     "loan_balance_amount": "60965.40"
   },
@@ -2722,7 +2722,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "284.51",
     "principal_amount": "914.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "914.59",
     "loan_balance_amount": "60050.81"
   },
@@ -2731,7 +2731,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "320.27",
     "principal_amount": "878.83",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "878.83",
     "loan_balance_amount": "59171.98"
   },
@@ -2740,7 +2740,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "295.86",
     "principal_amount": "903.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "903.24",
     "loan_balance_amount": "58268.74"
   },
@@ -2749,7 +2749,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "291.34",
     "principal_amount": "907.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "907.76",
     "loan_balance_amount": "57360.98"
   },
@@ -2758,7 +2758,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "286.80",
     "principal_amount": "912.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "912.30",
     "loan_balance_amount": "56448.68"
   },
@@ -2767,7 +2767,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "282.24",
     "principal_amount": "916.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "916.86",
     "loan_balance_amount": "55531.82"
   },
@@ -2776,7 +2776,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "277.66",
     "principal_amount": "921.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "921.44",
     "loan_balance_amount": "54610.38"
   },
@@ -2785,7 +2785,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "273.05",
     "principal_amount": "926.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "926.05",
     "loan_balance_amount": "53684.33"
   },
@@ -2794,7 +2794,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "268.42",
     "principal_amount": "930.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "930.68",
     "loan_balance_amount": "52753.65"
   },
@@ -2803,7 +2803,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "263.77",
     "principal_amount": "935.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "935.33",
     "loan_balance_amount": "51818.32"
   },
@@ -2812,7 +2812,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "259.09",
     "principal_amount": "940.01",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "940.01",
     "loan_balance_amount": "50878.31"
   },
@@ -2821,7 +2821,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "254.39",
     "principal_amount": "944.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "944.71",
     "loan_balance_amount": "49933.60"
   },
@@ -2830,7 +2830,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "241.35",
     "principal_amount": "957.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "957.75",
     "loan_balance_amount": "48975.85"
   },
@@ -2839,7 +2839,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "253.04",
     "principal_amount": "946.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "946.06",
     "loan_balance_amount": "48029.79"
   },
@@ -2848,7 +2848,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "240.15",
     "principal_amount": "958.95",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "958.95",
     "loan_balance_amount": "47070.84"
   },
@@ -2857,7 +2857,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "235.35",
     "principal_amount": "963.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "963.75",
     "loan_balance_amount": "46107.09"
   },
@@ -2866,7 +2866,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "230.54",
     "principal_amount": "968.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "968.56",
     "loan_balance_amount": "45138.53"
   },
@@ -2875,7 +2875,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "225.69",
     "principal_amount": "973.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "973.41",
     "loan_balance_amount": "44165.12"
   },
@@ -2884,7 +2884,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "220.83",
     "principal_amount": "978.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "978.27",
     "loan_balance_amount": "43186.85"
   },
@@ -2893,7 +2893,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "215.93",
     "principal_amount": "983.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "983.17",
     "loan_balance_amount": "42203.68"
   },
@@ -2902,7 +2902,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "211.02",
     "principal_amount": "988.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "988.08",
     "loan_balance_amount": "41215.60"
   },
@@ -2911,7 +2911,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "206.08",
     "principal_amount": "993.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "993.02",
     "loan_balance_amount": "40222.58"
   },
@@ -2920,7 +2920,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "201.11",
     "principal_amount": "997.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "997.99",
     "loan_balance_amount": "39224.59"
   },
@@ -2929,7 +2929,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "196.12",
     "principal_amount": "1002.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1002.98",
     "loan_balance_amount": "38221.61"
   },
@@ -2938,7 +2938,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "178.37",
     "principal_amount": "1020.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1020.73",
     "loan_balance_amount": "37200.88"
   },
@@ -2947,7 +2947,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "198.40",
     "principal_amount": "1000.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1000.70",
     "loan_balance_amount": "36200.18"
   },
@@ -2956,7 +2956,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "181.00",
     "principal_amount": "1018.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1018.10",
     "loan_balance_amount": "35182.08"
   },
@@ -2965,7 +2965,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "175.91",
     "principal_amount": "1023.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1023.19",
     "loan_balance_amount": "34158.89"
   },
@@ -2974,7 +2974,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "170.79",
     "principal_amount": "1028.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1028.31",
     "loan_balance_amount": "33130.58"
   },
@@ -2983,7 +2983,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "165.65",
     "principal_amount": "1033.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1033.45",
     "loan_balance_amount": "32097.13"
   },
@@ -2992,7 +2992,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "160.49",
     "principal_amount": "1038.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1038.61",
     "loan_balance_amount": "31058.52"
   },
@@ -3001,7 +3001,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "155.29",
     "principal_amount": "1043.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1043.81",
     "loan_balance_amount": "30014.71"
   },
@@ -3010,7 +3010,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "150.07",
     "principal_amount": "1049.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1049.03",
     "loan_balance_amount": "28965.68"
   },
@@ -3019,7 +3019,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "144.83",
     "principal_amount": "1054.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1054.27",
     "loan_balance_amount": "27911.41"
   },
@@ -3028,7 +3028,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "139.56",
     "principal_amount": "1059.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1059.54",
     "loan_balance_amount": "26851.87"
   },
@@ -3037,7 +3037,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "134.26",
     "principal_amount": "1064.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1064.84",
     "loan_balance_amount": "25787.03"
   },
@@ -3046,7 +3046,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "120.34",
     "principal_amount": "1078.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1078.76",
     "loan_balance_amount": "24708.27"
   },
@@ -3055,7 +3055,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "131.78",
     "principal_amount": "1067.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1067.32",
     "loan_balance_amount": "23640.95"
   },
@@ -3064,7 +3064,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "118.20",
     "principal_amount": "1080.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1080.90",
     "loan_balance_amount": "22560.05"
   },
@@ -3073,7 +3073,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "112.80",
     "principal_amount": "1086.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1086.30",
     "loan_balance_amount": "21473.75"
   },
@@ -3082,7 +3082,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "107.37",
     "principal_amount": "1091.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1091.73",
     "loan_balance_amount": "20382.02"
   },
@@ -3091,7 +3091,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "101.91",
     "principal_amount": "1097.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1097.19",
     "loan_balance_amount": "19284.83"
   },
@@ -3100,7 +3100,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "96.42",
     "principal_amount": "1102.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1102.68",
     "loan_balance_amount": "18182.15"
   },
@@ -3109,7 +3109,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "90.91",
     "principal_amount": "1108.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1108.19",
     "loan_balance_amount": "17073.96"
   },
@@ -3118,7 +3118,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "85.37",
     "principal_amount": "1113.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1113.73",
     "loan_balance_amount": "15960.23"
   },
@@ -3127,7 +3127,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "79.80",
     "principal_amount": "1119.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1119.30",
     "loan_balance_amount": "14840.93"
   },
@@ -3136,7 +3136,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "74.20",
     "principal_amount": "1124.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1124.90",
     "loan_balance_amount": "13716.03"
   },
@@ -3145,7 +3145,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "68.58",
     "principal_amount": "1130.52",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1130.52",
     "loan_balance_amount": "12585.51"
   },
@@ -3154,7 +3154,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "58.73",
     "principal_amount": "1140.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1140.37",
     "loan_balance_amount": "11445.14"
   },
@@ -3163,7 +3163,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "61.04",
     "principal_amount": "1138.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1138.06",
     "loan_balance_amount": "10307.08"
   },
@@ -3172,7 +3172,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "51.54",
     "principal_amount": "1147.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1147.56",
     "loan_balance_amount": "9159.52"
   },
@@ -3181,7 +3181,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "45.80",
     "principal_amount": "1153.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1153.30",
     "loan_balance_amount": "8006.22"
   },
@@ -3190,7 +3190,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "40.03",
     "principal_amount": "1159.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1159.07",
     "loan_balance_amount": "6847.15"
   },
@@ -3199,7 +3199,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "34.24",
     "principal_amount": "1164.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1164.86",
     "loan_balance_amount": "5682.29"
   },
@@ -3208,7 +3208,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "28.41",
     "principal_amount": "1170.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1170.69",
     "loan_balance_amount": "4511.60"
   },
@@ -3217,7 +3217,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "22.56",
     "principal_amount": "1176.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1176.54",
     "loan_balance_amount": "3335.06"
   },
@@ -3226,7 +3226,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "16.68",
     "principal_amount": "1182.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1182.42",
     "loan_balance_amount": "2152.64"
   },
@@ -3235,7 +3235,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "10.76",
     "principal_amount": "1188.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1188.34",
     "loan_balance_amount": "964.30"
   },
@@ -3244,7 +3244,7 @@
     "payment_amount": "969.12",
     "interest_amount": "4.82",
     "principal_amount": "964.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "964.30",
     "loan_balance_amount": "0.00"
   }

--- a/tests/snapshots/annuity_with_special_payment.json
+++ b/tests/snapshots/annuity_with_special_payment.json
@@ -13,7 +13,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1208.33",
     "principal_amount": "771.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "771.54",
     "loan_balance_amount": "299228.46"
   },
@@ -22,7 +22,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1288.34",
     "principal_amount": "691.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "691.53",
     "loan_balance_amount": "298536.93"
   },
@@ -31,7 +31,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1243.90",
     "principal_amount": "735.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "735.97",
     "loan_balance_amount": "297800.96"
   },
@@ -40,7 +40,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1240.84",
     "principal_amount": "739.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "739.03",
     "loan_balance_amount": "297061.93"
   },
@@ -49,7 +49,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1237.76",
     "principal_amount": "742.11",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "742.11",
     "loan_balance_amount": "296319.82"
   },
@@ -58,7 +58,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1234.67",
     "principal_amount": "745.20",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "745.20",
     "loan_balance_amount": "295574.62"
   },
@@ -67,7 +67,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1231.56",
     "principal_amount": "748.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "748.31",
     "loan_balance_amount": "294826.31"
   },
@@ -76,7 +76,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1228.44",
     "principal_amount": "751.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "751.43",
     "loan_balance_amount": "294074.88"
   },
@@ -85,7 +85,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1225.31",
     "principal_amount": "754.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "754.56",
     "loan_balance_amount": "293320.32"
   },
@@ -94,7 +94,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1222.17",
     "principal_amount": "757.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "757.70",
     "loan_balance_amount": "292562.62"
   },
@@ -103,7 +103,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1219.01",
     "principal_amount": "760.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "760.86",
     "loan_balance_amount": "291801.76"
   },
@@ -121,7 +121,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1034.59",
     "principal_amount": "945.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "945.28",
     "loan_balance_amount": "265092.45"
   },
@@ -130,7 +130,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1178.19",
     "principal_amount": "801.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "801.68",
     "loan_balance_amount": "264290.77"
   },
@@ -139,7 +139,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1101.21",
     "principal_amount": "878.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "878.66",
     "loan_balance_amount": "263412.11"
   },
@@ -148,7 +148,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1097.55",
     "principal_amount": "882.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "882.32",
     "loan_balance_amount": "262529.79"
   },
@@ -157,7 +157,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1093.87",
     "principal_amount": "886.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "886.00",
     "loan_balance_amount": "261643.79"
   },
@@ -166,7 +166,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1090.18",
     "principal_amount": "889.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "889.69",
     "loan_balance_amount": "260754.10"
   },
@@ -175,7 +175,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1086.48",
     "principal_amount": "893.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "893.39",
     "loan_balance_amount": "259860.71"
   },
@@ -184,7 +184,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1082.75",
     "principal_amount": "897.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "897.12",
     "loan_balance_amount": "258963.59"
   },
@@ -193,7 +193,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1079.01",
     "principal_amount": "900.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "900.86",
     "loan_balance_amount": "258062.73"
   },
@@ -202,7 +202,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1075.26",
     "principal_amount": "904.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "904.61",
     "loan_balance_amount": "257158.12"
   },
@@ -211,7 +211,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1071.49",
     "principal_amount": "908.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "908.38",
     "loan_balance_amount": "256249.74"
   },
@@ -220,7 +220,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1067.71",
     "principal_amount": "912.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "912.16",
     "loan_balance_amount": "255337.58"
   },
@@ -229,7 +229,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "992.98",
     "principal_amount": "986.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "986.89",
     "loan_balance_amount": "254350.69"
   },
@@ -238,7 +238,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1130.45",
     "principal_amount": "849.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "849.42",
     "loan_balance_amount": "253501.27"
   },
@@ -247,7 +247,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1056.26",
     "principal_amount": "923.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "923.61",
     "loan_balance_amount": "252577.66"
   },
@@ -256,7 +256,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1052.41",
     "principal_amount": "927.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "927.46",
     "loan_balance_amount": "251650.20"
   },
@@ -265,7 +265,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1048.54",
     "principal_amount": "931.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "931.33",
     "loan_balance_amount": "250718.87"
   },
@@ -274,7 +274,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1044.66",
     "principal_amount": "935.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "935.21",
     "loan_balance_amount": "249783.66"
   },
@@ -283,7 +283,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1040.77",
     "principal_amount": "939.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "939.10",
     "loan_balance_amount": "248844.56"
   },
@@ -292,7 +292,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1036.85",
     "principal_amount": "943.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "943.02",
     "loan_balance_amount": "247901.54"
   },
@@ -301,7 +301,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1032.92",
     "principal_amount": "946.95",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "946.95",
     "loan_balance_amount": "246954.59"
   },
@@ -310,7 +310,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1028.98",
     "principal_amount": "950.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "950.89",
     "loan_balance_amount": "246003.70"
   },
@@ -319,7 +319,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1025.02",
     "principal_amount": "954.85",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "954.85",
     "loan_balance_amount": "245048.85"
   },
@@ -328,7 +328,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1021.04",
     "principal_amount": "958.83",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "958.83",
     "loan_balance_amount": "244090.02"
   },
@@ -337,7 +337,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "949.24",
     "principal_amount": "1030.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1030.63",
     "loan_balance_amount": "243059.39"
   },
@@ -346,7 +346,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1080.26",
     "principal_amount": "899.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "899.61",
     "loan_balance_amount": "242159.78"
   },
@@ -355,7 +355,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1009.00",
     "principal_amount": "970.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "970.87",
     "loan_balance_amount": "241188.91"
   },
@@ -364,7 +364,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1004.95",
     "principal_amount": "974.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "974.92",
     "loan_balance_amount": "240213.99"
   },
@@ -373,7 +373,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "1000.89",
     "principal_amount": "978.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "978.98",
     "loan_balance_amount": "239235.01"
   },
@@ -382,7 +382,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "996.81",
     "principal_amount": "983.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "983.06",
     "loan_balance_amount": "238251.95"
   },
@@ -391,7 +391,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "992.72",
     "principal_amount": "987.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "987.15",
     "loan_balance_amount": "237264.80"
   },
@@ -400,7 +400,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "988.60",
     "principal_amount": "991.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "991.27",
     "loan_balance_amount": "236273.53"
   },
@@ -409,7 +409,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "984.47",
     "principal_amount": "995.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "995.40",
     "loan_balance_amount": "235278.13"
   },
@@ -418,7 +418,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "980.33",
     "principal_amount": "999.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "999.54",
     "loan_balance_amount": "234278.59"
   },
@@ -427,7 +427,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "976.16",
     "principal_amount": "1003.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1003.71",
     "loan_balance_amount": "233274.88"
   },
@@ -436,7 +436,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "971.98",
     "principal_amount": "1007.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1007.89",
     "loan_balance_amount": "232266.99"
   },
@@ -445,7 +445,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "935.52",
     "principal_amount": "1044.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1044.35",
     "loan_balance_amount": "231222.64"
   },
@@ -454,7 +454,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "995.54",
     "principal_amount": "984.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "984.33",
     "loan_balance_amount": "230238.31"
   },
@@ -463,7 +463,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "959.33",
     "principal_amount": "1020.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1020.54",
     "loan_balance_amount": "229217.77"
   },
@@ -472,7 +472,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "955.07",
     "principal_amount": "1024.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1024.80",
     "loan_balance_amount": "228192.97"
   },
@@ -481,7 +481,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "950.80",
     "principal_amount": "1029.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1029.07",
     "loan_balance_amount": "227163.90"
   },
@@ -490,7 +490,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "946.52",
     "principal_amount": "1033.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1033.35",
     "loan_balance_amount": "226130.55"
   },
@@ -499,7 +499,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "942.21",
     "principal_amount": "1037.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1037.66",
     "loan_balance_amount": "225092.89"
   },
@@ -508,7 +508,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "937.89",
     "principal_amount": "1041.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1041.98",
     "loan_balance_amount": "224050.91"
   },
@@ -517,7 +517,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "933.55",
     "principal_amount": "1046.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1046.32",
     "loan_balance_amount": "223004.59"
   },
@@ -526,7 +526,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "929.19",
     "principal_amount": "1050.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1050.68",
     "loan_balance_amount": "221953.91"
   },
@@ -535,7 +535,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "924.81",
     "principal_amount": "1055.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1055.06",
     "loan_balance_amount": "220898.85"
   },
@@ -544,7 +544,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "920.41",
     "principal_amount": "1059.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1059.46",
     "loan_balance_amount": "219839.39"
   },
@@ -553,7 +553,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "854.93",
     "principal_amount": "1124.94",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1124.94",
     "loan_balance_amount": "218714.45"
   },
@@ -562,7 +562,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "972.06",
     "principal_amount": "1007.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1007.81",
     "loan_balance_amount": "217706.64"
   },
@@ -571,7 +571,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "907.11",
     "principal_amount": "1072.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1072.76",
     "loan_balance_amount": "216633.88"
   },
@@ -580,7 +580,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "902.64",
     "principal_amount": "1077.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1077.23",
     "loan_balance_amount": "215556.65"
   },
@@ -589,7 +589,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "898.15",
     "principal_amount": "1081.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1081.72",
     "loan_balance_amount": "214474.93"
   },
@@ -598,7 +598,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "893.65",
     "principal_amount": "1086.22",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1086.22",
     "loan_balance_amount": "213388.71"
   },
@@ -607,7 +607,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "889.12",
     "principal_amount": "1090.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1090.75",
     "loan_balance_amount": "212297.96"
   },
@@ -616,7 +616,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "884.57",
     "principal_amount": "1095.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1095.30",
     "loan_balance_amount": "211202.66"
   },
@@ -625,7 +625,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "880.01",
     "principal_amount": "1099.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1099.86",
     "loan_balance_amount": "210102.80"
   },
@@ -634,7 +634,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "875.43",
     "principal_amount": "1104.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1104.44",
     "loan_balance_amount": "208998.36"
   },
@@ -643,7 +643,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "870.83",
     "principal_amount": "1109.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1109.04",
     "loan_balance_amount": "207889.32"
   },
@@ -652,7 +652,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "866.21",
     "principal_amount": "1113.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1113.66",
     "loan_balance_amount": "206775.66"
   },
@@ -661,7 +661,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "804.13",
     "principal_amount": "1175.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1175.74",
     "loan_balance_amount": "205599.92"
   },
@@ -670,7 +670,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "913.78",
     "principal_amount": "1066.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1066.09",
     "loan_balance_amount": "204533.83"
   },
@@ -679,7 +679,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "852.22",
     "principal_amount": "1127.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1127.65",
     "loan_balance_amount": "203406.18"
   },
@@ -688,7 +688,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "847.53",
     "principal_amount": "1132.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1132.34",
     "loan_balance_amount": "202273.84"
   },
@@ -697,7 +697,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "842.81",
     "principal_amount": "1137.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1137.06",
     "loan_balance_amount": "201136.78"
   },
@@ -706,7 +706,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "838.07",
     "principal_amount": "1141.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1141.80",
     "loan_balance_amount": "199994.98"
   },
@@ -715,7 +715,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "833.31",
     "principal_amount": "1146.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1146.56",
     "loan_balance_amount": "198848.42"
   },
@@ -724,7 +724,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "828.54",
     "principal_amount": "1151.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1151.33",
     "loan_balance_amount": "197697.09"
   },
@@ -733,7 +733,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "823.74",
     "principal_amount": "1156.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1156.13",
     "loan_balance_amount": "196540.96"
   },
@@ -742,7 +742,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "818.92",
     "principal_amount": "1160.95",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1160.95",
     "loan_balance_amount": "195380.01"
   },
@@ -751,7 +751,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "814.08",
     "principal_amount": "1165.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1165.79",
     "loan_balance_amount": "194214.22"
   },
@@ -760,7 +760,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "809.23",
     "principal_amount": "1170.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1170.64",
     "loan_balance_amount": "193043.58"
   },
@@ -769,7 +769,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "750.73",
     "principal_amount": "1229.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1229.14",
     "loan_balance_amount": "191814.44"
   },
@@ -778,7 +778,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "852.51",
     "principal_amount": "1127.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1127.36",
     "loan_balance_amount": "190687.08"
   },
@@ -787,7 +787,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "794.53",
     "principal_amount": "1185.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1185.34",
     "loan_balance_amount": "189501.74"
   },
@@ -796,7 +796,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "789.59",
     "principal_amount": "1190.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1190.28",
     "loan_balance_amount": "188311.46"
   },
@@ -805,7 +805,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "784.63",
     "principal_amount": "1195.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1195.24",
     "loan_balance_amount": "187116.22"
   },
@@ -814,7 +814,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "779.65",
     "principal_amount": "1200.22",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1200.22",
     "loan_balance_amount": "185916.00"
   },
@@ -823,7 +823,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "774.65",
     "principal_amount": "1205.22",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1205.22",
     "loan_balance_amount": "184710.78"
   },
@@ -832,7 +832,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "769.63",
     "principal_amount": "1210.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1210.24",
     "loan_balance_amount": "183500.54"
   },
@@ -841,7 +841,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "764.59",
     "principal_amount": "1215.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1215.28",
     "loan_balance_amount": "182285.26"
   },
@@ -850,7 +850,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "759.52",
     "principal_amount": "1220.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1220.35",
     "loan_balance_amount": "181064.91"
   },
@@ -859,7 +859,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "754.44",
     "principal_amount": "1225.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1225.43",
     "loan_balance_amount": "179839.48"
   },
@@ -868,7 +868,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "749.33",
     "principal_amount": "1230.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1230.54",
     "loan_balance_amount": "178608.94"
   },
@@ -877,7 +877,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "719.40",
     "principal_amount": "1260.47",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1260.47",
     "loan_balance_amount": "177348.47"
   },
@@ -886,7 +886,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "763.58",
     "principal_amount": "1216.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1216.29",
     "loan_balance_amount": "176132.18"
   },
@@ -895,7 +895,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "733.88",
     "principal_amount": "1245.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1245.99",
     "loan_balance_amount": "174886.19"
   },
@@ -904,7 +904,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "728.69",
     "principal_amount": "1251.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1251.18",
     "loan_balance_amount": "173635.01"
   },
@@ -913,7 +913,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "723.48",
     "principal_amount": "1256.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1256.39",
     "loan_balance_amount": "172378.62"
   },
@@ -922,7 +922,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "718.24",
     "principal_amount": "1261.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1261.63",
     "loan_balance_amount": "171116.99"
   },
@@ -931,7 +931,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "712.99",
     "principal_amount": "1266.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1266.88",
     "loan_balance_amount": "169850.11"
   },
@@ -940,7 +940,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "707.71",
     "principal_amount": "1272.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1272.16",
     "loan_balance_amount": "168577.95"
   },
@@ -949,7 +949,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "702.41",
     "principal_amount": "1277.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1277.46",
     "loan_balance_amount": "167300.49"
   },
@@ -958,7 +958,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "697.09",
     "principal_amount": "1282.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1282.78",
     "loan_balance_amount": "166017.71"
   },
@@ -967,7 +967,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "691.74",
     "principal_amount": "1288.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1288.13",
     "loan_balance_amount": "164729.58"
   },
@@ -976,7 +976,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "686.37",
     "principal_amount": "1293.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1293.50",
     "loan_balance_amount": "163436.08"
   },
@@ -985,7 +985,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "635.58",
     "principal_amount": "1344.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1344.29",
     "loan_balance_amount": "162091.79"
   },
@@ -994,7 +994,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "720.41",
     "principal_amount": "1259.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1259.46",
     "loan_balance_amount": "160832.33"
   },
@@ -1003,7 +1003,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "670.13",
     "principal_amount": "1309.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1309.74",
     "loan_balance_amount": "159522.59"
   },
@@ -1012,7 +1012,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "664.68",
     "principal_amount": "1315.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1315.19",
     "loan_balance_amount": "158207.40"
   },
@@ -1021,7 +1021,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "659.20",
     "principal_amount": "1320.67",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1320.67",
     "loan_balance_amount": "156886.73"
   },
@@ -1030,7 +1030,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "653.69",
     "principal_amount": "1326.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1326.18",
     "loan_balance_amount": "155560.55"
   },
@@ -1039,7 +1039,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "648.17",
     "principal_amount": "1331.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1331.70",
     "loan_balance_amount": "154228.85"
   },
@@ -1048,7 +1048,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "642.62",
     "principal_amount": "1337.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1337.25",
     "loan_balance_amount": "152891.60"
   },
@@ -1057,7 +1057,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "637.05",
     "principal_amount": "1342.82",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1342.82",
     "loan_balance_amount": "151548.78"
   },
@@ -1066,7 +1066,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "631.45",
     "principal_amount": "1348.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1348.42",
     "loan_balance_amount": "150200.36"
   },
@@ -1075,7 +1075,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "625.83",
     "principal_amount": "1354.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1354.04",
     "loan_balance_amount": "148846.32"
   },
@@ -1084,7 +1084,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "620.19",
     "principal_amount": "1359.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1359.68",
     "loan_balance_amount": "147486.64"
   },
@@ -1093,7 +1093,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "573.56",
     "principal_amount": "1406.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1406.31",
     "loan_balance_amount": "146080.33"
   },
@@ -1102,7 +1102,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "649.25",
     "principal_amount": "1330.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1330.62",
     "loan_balance_amount": "144749.71"
   },
@@ -1111,7 +1111,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "603.12",
     "principal_amount": "1376.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1376.75",
     "loan_balance_amount": "143372.96"
   },
@@ -1120,7 +1120,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "597.39",
     "principal_amount": "1382.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1382.48",
     "loan_balance_amount": "141990.48"
   },
@@ -1129,7 +1129,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "591.63",
     "principal_amount": "1388.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1388.24",
     "loan_balance_amount": "140602.24"
   },
@@ -1138,7 +1138,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "585.84",
     "principal_amount": "1394.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1394.03",
     "loan_balance_amount": "139208.21"
   },
@@ -1147,7 +1147,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "580.03",
     "principal_amount": "1399.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1399.84",
     "loan_balance_amount": "137808.37"
   },
@@ -1156,7 +1156,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "574.20",
     "principal_amount": "1405.67",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1405.67",
     "loan_balance_amount": "136402.70"
   },
@@ -1165,7 +1165,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "568.34",
     "principal_amount": "1411.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1411.53",
     "loan_balance_amount": "134991.17"
   },
@@ -1174,7 +1174,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "562.46",
     "principal_amount": "1417.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1417.41",
     "loan_balance_amount": "133573.76"
   },
@@ -1183,7 +1183,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "556.56",
     "principal_amount": "1423.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1423.31",
     "loan_balance_amount": "132150.45"
   },
@@ -1192,7 +1192,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "550.63",
     "principal_amount": "1429.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1429.24",
     "loan_balance_amount": "130721.21"
   },
@@ -1201,7 +1201,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "508.36",
     "principal_amount": "1471.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1471.51",
     "loan_balance_amount": "129249.70"
   },
@@ -1210,7 +1210,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "574.44",
     "principal_amount": "1405.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1405.43",
     "loan_balance_amount": "127844.27"
   },
@@ -1219,7 +1219,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "532.68",
     "principal_amount": "1447.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1447.19",
     "loan_balance_amount": "126397.08"
   },
@@ -1228,7 +1228,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "526.65",
     "principal_amount": "1453.22",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1453.22",
     "loan_balance_amount": "124943.86"
   },
@@ -1237,7 +1237,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "520.60",
     "principal_amount": "1459.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1459.27",
     "loan_balance_amount": "123484.59"
   },
@@ -1246,7 +1246,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "514.52",
     "principal_amount": "1465.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1465.35",
     "loan_balance_amount": "122019.24"
   },
@@ -1255,7 +1255,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "508.41",
     "principal_amount": "1471.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1471.46",
     "loan_balance_amount": "120547.78"
   },
@@ -1264,7 +1264,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "502.28",
     "principal_amount": "1477.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1477.59",
     "loan_balance_amount": "119070.19"
   },
@@ -1273,7 +1273,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "496.13",
     "principal_amount": "1483.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1483.74",
     "loan_balance_amount": "117586.45"
   },
@@ -1282,7 +1282,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "489.94",
     "principal_amount": "1489.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1489.93",
     "loan_balance_amount": "116096.52"
   },
@@ -1291,7 +1291,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "483.74",
     "principal_amount": "1496.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1496.13",
     "loan_balance_amount": "114600.39"
   },
@@ -1300,7 +1300,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "477.50",
     "principal_amount": "1502.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1502.37",
     "loan_balance_amount": "113098.02"
   },
@@ -1309,7 +1309,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "455.53",
     "principal_amount": "1524.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1524.34",
     "loan_balance_amount": "111573.68"
   },
@@ -1318,7 +1318,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "480.39",
     "principal_amount": "1499.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1499.48",
     "loan_balance_amount": "110074.20"
   },
@@ -1327,7 +1327,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "458.64",
     "principal_amount": "1521.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1521.23",
     "loan_balance_amount": "108552.97"
   },
@@ -1336,7 +1336,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "452.30",
     "principal_amount": "1527.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1527.57",
     "loan_balance_amount": "107025.40"
   },
@@ -1345,7 +1345,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "445.94",
     "principal_amount": "1533.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1533.93",
     "loan_balance_amount": "105491.47"
   },
@@ -1354,7 +1354,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "439.55",
     "principal_amount": "1540.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1540.32",
     "loan_balance_amount": "103951.15"
   },
@@ -1363,7 +1363,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "433.13",
     "principal_amount": "1546.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1546.74",
     "loan_balance_amount": "102404.41"
   },
@@ -1372,7 +1372,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "426.69",
     "principal_amount": "1553.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1553.18",
     "loan_balance_amount": "100851.23"
   },
@@ -1381,7 +1381,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "420.21",
     "principal_amount": "1559.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1559.66",
     "loan_balance_amount": "99291.57"
   },
@@ -1390,7 +1390,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "413.71",
     "principal_amount": "1566.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1566.16",
     "loan_balance_amount": "97725.41"
   },
@@ -1399,7 +1399,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "407.19",
     "principal_amount": "1572.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1572.68",
     "loan_balance_amount": "96152.73"
   },
@@ -1408,7 +1408,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "400.64",
     "principal_amount": "1579.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1579.23",
     "loan_balance_amount": "94573.50"
   },
@@ -1417,7 +1417,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "367.79",
     "principal_amount": "1612.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1612.08",
     "loan_balance_amount": "92961.42"
   },
@@ -1426,7 +1426,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "413.16",
     "principal_amount": "1566.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1566.71",
     "loan_balance_amount": "91394.71"
   },
@@ -1435,7 +1435,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "380.81",
     "principal_amount": "1599.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1599.06",
     "loan_balance_amount": "89795.65"
   },
@@ -1444,7 +1444,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "374.15",
     "principal_amount": "1605.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1605.72",
     "loan_balance_amount": "88189.93"
   },
@@ -1453,7 +1453,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "367.46",
     "principal_amount": "1612.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1612.41",
     "loan_balance_amount": "86577.52"
   },
@@ -1462,7 +1462,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "360.74",
     "principal_amount": "1619.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1619.13",
     "loan_balance_amount": "84958.39"
   },
@@ -1471,7 +1471,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "353.99",
     "principal_amount": "1625.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1625.88",
     "loan_balance_amount": "83332.51"
   },
@@ -1480,7 +1480,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "347.22",
     "principal_amount": "1632.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1632.65",
     "loan_balance_amount": "81699.86"
   },
@@ -1489,7 +1489,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "340.42",
     "principal_amount": "1639.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1639.45",
     "loan_balance_amount": "80060.41"
   },
@@ -1498,7 +1498,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "333.59",
     "principal_amount": "1646.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1646.28",
     "loan_balance_amount": "78414.13"
   },
@@ -1507,7 +1507,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "326.73",
     "principal_amount": "1653.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1653.14",
     "loan_balance_amount": "76760.99"
   },
@@ -1516,7 +1516,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "319.84",
     "principal_amount": "1660.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1660.03",
     "loan_balance_amount": "75100.96"
   },
@@ -1525,7 +1525,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "292.06",
     "principal_amount": "1687.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1687.81",
     "loan_balance_amount": "73413.15"
   },
@@ -1534,7 +1534,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "326.28",
     "principal_amount": "1653.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1653.59",
     "loan_balance_amount": "71759.56"
   },
@@ -1543,7 +1543,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "299.00",
     "principal_amount": "1680.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1680.87",
     "loan_balance_amount": "70078.69"
   },
@@ -1552,7 +1552,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "291.99",
     "principal_amount": "1687.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1687.88",
     "loan_balance_amount": "68390.81"
   },
@@ -1561,7 +1561,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "284.96",
     "principal_amount": "1694.91",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1694.91",
     "loan_balance_amount": "66695.90"
   },
@@ -1570,7 +1570,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "277.90",
     "principal_amount": "1701.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1701.97",
     "loan_balance_amount": "64993.93"
   },
@@ -1579,7 +1579,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "270.81",
     "principal_amount": "1709.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1709.06",
     "loan_balance_amount": "63284.87"
   },
@@ -1588,7 +1588,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "263.69",
     "principal_amount": "1716.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1716.18",
     "loan_balance_amount": "61568.69"
   },
@@ -1597,7 +1597,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "256.54",
     "principal_amount": "1723.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1723.33",
     "loan_balance_amount": "59845.36"
   },
@@ -1606,7 +1606,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "249.36",
     "principal_amount": "1730.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1730.51",
     "loan_balance_amount": "58114.85"
   },
@@ -1615,7 +1615,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "242.15",
     "principal_amount": "1737.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1737.72",
     "loan_balance_amount": "56377.13"
   },
@@ -1624,7 +1624,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "234.90",
     "principal_amount": "1744.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1744.97",
     "loan_balance_amount": "54632.16"
   },
@@ -1633,7 +1633,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "212.46",
     "principal_amount": "1767.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1767.41",
     "loan_balance_amount": "52864.75"
   },
@@ -1642,7 +1642,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "234.95",
     "principal_amount": "1744.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1744.92",
     "loan_balance_amount": "51119.83"
   },
@@ -1651,7 +1651,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "213.00",
     "principal_amount": "1766.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1766.87",
     "loan_balance_amount": "49352.96"
   },
@@ -1660,7 +1660,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "205.64",
     "principal_amount": "1774.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1774.23",
     "loan_balance_amount": "47578.73"
   },
@@ -1669,7 +1669,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "198.24",
     "principal_amount": "1781.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1781.63",
     "loan_balance_amount": "45797.10"
   },
@@ -1678,7 +1678,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "190.82",
     "principal_amount": "1789.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1789.05",
     "loan_balance_amount": "44008.05"
   },
@@ -1687,7 +1687,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "183.37",
     "principal_amount": "1796.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1796.50",
     "loan_balance_amount": "42211.55"
   },
@@ -1696,7 +1696,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "175.88",
     "principal_amount": "1803.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1803.99",
     "loan_balance_amount": "40407.56"
   },
@@ -1705,7 +1705,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "168.36",
     "principal_amount": "1811.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1811.51",
     "loan_balance_amount": "38596.05"
   },
@@ -1714,7 +1714,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "160.82",
     "principal_amount": "1819.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1819.05",
     "loan_balance_amount": "36777.00"
   },
@@ -1723,7 +1723,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "153.24",
     "principal_amount": "1826.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1826.63",
     "loan_balance_amount": "34950.37"
   },
@@ -1732,7 +1732,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "145.63",
     "principal_amount": "1834.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1834.24",
     "loan_balance_amount": "33116.13"
   },
@@ -1741,7 +1741,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "133.38",
     "principal_amount": "1846.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1846.49",
     "loan_balance_amount": "31269.64"
   },
@@ -1750,7 +1750,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "134.63",
     "principal_amount": "1845.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1845.24",
     "loan_balance_amount": "29424.40"
   },
@@ -1759,7 +1759,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "122.60",
     "principal_amount": "1857.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1857.27",
     "loan_balance_amount": "27567.13"
   },
@@ -1768,7 +1768,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "114.86",
     "principal_amount": "1865.01",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1865.01",
     "loan_balance_amount": "25702.12"
   },
@@ -1777,7 +1777,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "107.09",
     "principal_amount": "1872.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1872.78",
     "loan_balance_amount": "23829.34"
   },
@@ -1786,7 +1786,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "99.29",
     "principal_amount": "1880.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1880.58",
     "loan_balance_amount": "21948.76"
   },
@@ -1795,7 +1795,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "91.45",
     "principal_amount": "1888.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1888.42",
     "loan_balance_amount": "20060.34"
   },
@@ -1804,7 +1804,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "83.58",
     "principal_amount": "1896.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1896.29",
     "loan_balance_amount": "18164.05"
   },
@@ -1813,7 +1813,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "75.68",
     "principal_amount": "1904.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1904.19",
     "loan_balance_amount": "16259.86"
   },
@@ -1822,7 +1822,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "67.75",
     "principal_amount": "1912.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1912.12",
     "loan_balance_amount": "14347.74"
   },
@@ -1831,7 +1831,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "59.78",
     "principal_amount": "1920.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1920.09",
     "loan_balance_amount": "12427.65"
   },
@@ -1840,7 +1840,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "51.78",
     "principal_amount": "1928.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1928.09",
     "loan_balance_amount": "10499.56"
   },
@@ -1849,7 +1849,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "40.83",
     "principal_amount": "1939.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1939.04",
     "loan_balance_amount": "8560.52"
   },
@@ -1858,7 +1858,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "38.05",
     "principal_amount": "1941.82",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1941.82",
     "loan_balance_amount": "6618.70"
   },
@@ -1867,7 +1867,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "27.58",
     "principal_amount": "1952.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1952.29",
     "loan_balance_amount": "4666.41"
   },
@@ -1876,7 +1876,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "19.44",
     "principal_amount": "1960.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1960.43",
     "loan_balance_amount": "2705.98"
   },
@@ -1885,7 +1885,7 @@
     "payment_amount": "1979.87",
     "interest_amount": "11.27",
     "principal_amount": "1968.60",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1968.60",
     "loan_balance_amount": "737.38"
   },
@@ -1894,7 +1894,7 @@
     "payment_amount": "740.45",
     "interest_amount": "3.07",
     "principal_amount": "737.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "737.38",
     "loan_balance_amount": "0.00"
   }

--- a/tests/snapshots/bug_special_payment_on_odd_date.json
+++ b/tests/snapshots/bug_special_payment_on_odd_date.json
@@ -13,7 +13,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "670.83",
     "principal_amount": "676.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "676.30",
     "loan_balance_amount": "299323.70"
   },
@@ -22,7 +22,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "873.03",
     "principal_amount": "474.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "474.10",
     "loan_balance_amount": "298849.60"
   },
@@ -31,7 +31,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "871.64",
     "principal_amount": "475.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "475.49",
     "loan_balance_amount": "298374.11"
   },
@@ -40,15 +40,15 @@
     "payment_amount": "1347.13",
     "interest_amount": "870.26",
     "principal_amount": "476.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "476.87",
     "loan_balance_amount": "297897.24"
   },
   {
     "date": "2026-01-05T00:00:00",
     "payment_amount": "1300.00",
-    "interest_amount": "0",
-    "principal_amount": "0",
+    "interest_amount": "0.00",
+    "principal_amount": "0.00",
     "special_principal_amount": "1300.00",
     "total_principal_amount": "1300.00",
     "loan_balance_amount": "296597.24"
@@ -58,7 +58,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "865.71",
     "principal_amount": "481.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "481.42",
     "loan_balance_amount": "296115.82"
   },
@@ -67,7 +67,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "806.09",
     "principal_amount": "541.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "541.04",
     "loan_balance_amount": "295574.78"
   },
@@ -76,15 +76,15 @@
     "payment_amount": "1347.13",
     "interest_amount": "919.57",
     "principal_amount": "427.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "427.56",
     "loan_balance_amount": "295147.22"
   },
   {
     "date": "2026-04-05T00:00:00",
     "payment_amount": "1300.00",
-    "interest_amount": "0",
-    "principal_amount": "0",
+    "interest_amount": "0.00",
+    "principal_amount": "0.00",
     "special_principal_amount": "1300.00",
     "total_principal_amount": "1300.00",
     "loan_balance_amount": "293847.22"
@@ -94,7 +94,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "857.68",
     "principal_amount": "489.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "489.45",
     "loan_balance_amount": "293357.77"
   },
@@ -103,7 +103,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "855.63",
     "principal_amount": "491.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "491.50",
     "loan_balance_amount": "292866.27"
   },
@@ -112,15 +112,15 @@
     "payment_amount": "1347.13",
     "interest_amount": "854.19",
     "principal_amount": "492.94",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "492.94",
     "loan_balance_amount": "292373.33"
   },
   {
     "date": "2026-07-05T00:00:00",
     "payment_amount": "1300.00",
-    "interest_amount": "0",
-    "principal_amount": "0",
+    "interest_amount": "0.00",
+    "principal_amount": "0.00",
     "special_principal_amount": "1300.00",
     "total_principal_amount": "1300.00",
     "loan_balance_amount": "291073.33"
@@ -130,7 +130,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "849.60",
     "principal_amount": "497.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "497.53",
     "loan_balance_amount": "290575.80"
   },
@@ -139,7 +139,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "847.51",
     "principal_amount": "499.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "499.62",
     "loan_balance_amount": "290076.18"
   },
@@ -148,15 +148,15 @@
     "payment_amount": "1347.13",
     "interest_amount": "846.06",
     "principal_amount": "501.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "501.07",
     "loan_balance_amount": "289575.11"
   },
   {
     "date": "2026-10-05T00:00:00",
     "payment_amount": "1300.00",
-    "interest_amount": "0",
-    "principal_amount": "0",
+    "interest_amount": "0.00",
+    "principal_amount": "0.00",
     "special_principal_amount": "1300.00",
     "total_principal_amount": "1300.00",
     "loan_balance_amount": "288275.11"
@@ -166,7 +166,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "841.44",
     "principal_amount": "505.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "505.69",
     "loan_balance_amount": "287769.42"
   },
@@ -175,7 +175,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "839.33",
     "principal_amount": "507.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "507.80",
     "loan_balance_amount": "287261.62"
   },
@@ -184,15 +184,15 @@
     "payment_amount": "1347.13",
     "interest_amount": "837.85",
     "principal_amount": "509.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "509.28",
     "loan_balance_amount": "286752.34"
   },
   {
     "date": "2027-01-05T00:00:00",
     "payment_amount": "1300.00",
-    "interest_amount": "0",
-    "principal_amount": "0",
+    "interest_amount": "0.00",
+    "principal_amount": "0.00",
     "special_principal_amount": "1300.00",
     "total_principal_amount": "1300.00",
     "loan_balance_amount": "285452.34"
@@ -202,7 +202,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "833.20",
     "principal_amount": "513.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "513.93",
     "loan_balance_amount": "284938.41"
   },
@@ -211,7 +211,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "775.67",
     "principal_amount": "571.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "571.46",
     "loan_balance_amount": "284366.95"
   },
@@ -220,15 +220,15 @@
     "payment_amount": "1347.13",
     "interest_amount": "884.70",
     "principal_amount": "462.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "462.43",
     "loan_balance_amount": "283904.52"
   },
   {
     "date": "2027-04-05T00:00:00",
     "payment_amount": "1300.00",
-    "interest_amount": "0",
-    "principal_amount": "0",
+    "interest_amount": "0.00",
+    "principal_amount": "0.00",
     "special_principal_amount": "1300.00",
     "total_principal_amount": "1300.00",
     "loan_balance_amount": "282604.52"
@@ -238,7 +238,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "824.90",
     "principal_amount": "522.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "522.23",
     "loan_balance_amount": "282082.29"
   },
@@ -247,7 +247,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "822.74",
     "principal_amount": "524.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "524.39",
     "loan_balance_amount": "281557.90"
   },
@@ -256,15 +256,15 @@
     "payment_amount": "1347.13",
     "interest_amount": "821.21",
     "principal_amount": "525.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "525.92",
     "loan_balance_amount": "281031.98"
   },
   {
     "date": "2027-07-05T00:00:00",
     "payment_amount": "1300.00",
-    "interest_amount": "0",
-    "principal_amount": "0",
+    "interest_amount": "0.00",
+    "principal_amount": "0.00",
     "special_principal_amount": "1300.00",
     "total_principal_amount": "1300.00",
     "loan_balance_amount": "279731.98"
@@ -274,7 +274,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "816.51",
     "principal_amount": "530.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "530.62",
     "loan_balance_amount": "279201.36"
   },
@@ -283,7 +283,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "814.34",
     "principal_amount": "532.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "532.79",
     "loan_balance_amount": "278668.57"
   },
@@ -292,15 +292,15 @@
     "payment_amount": "1347.13",
     "interest_amount": "812.78",
     "principal_amount": "534.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "534.35",
     "loan_balance_amount": "278134.22"
   },
   {
     "date": "2027-10-05T00:00:00",
     "payment_amount": "1300.00",
-    "interest_amount": "0",
-    "principal_amount": "0",
+    "interest_amount": "0.00",
+    "principal_amount": "0.00",
     "special_principal_amount": "1300.00",
     "total_principal_amount": "1300.00",
     "loan_balance_amount": "276834.22"
@@ -310,7 +310,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "808.06",
     "principal_amount": "539.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "539.07",
     "loan_balance_amount": "276295.15"
   },
@@ -319,7 +319,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "805.86",
     "principal_amount": "541.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "541.27",
     "loan_balance_amount": "275753.88"
   },
@@ -328,7 +328,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "804.28",
     "principal_amount": "542.85",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "542.85",
     "loan_balance_amount": "275211.03"
   },
@@ -337,7 +337,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "802.70",
     "principal_amount": "544.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "544.43",
     "loan_balance_amount": "274666.60"
   },
@@ -346,7 +346,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "774.41",
     "principal_amount": "572.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "572.72",
     "loan_balance_amount": "274093.88"
   },
@@ -355,7 +355,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "826.09",
     "principal_amount": "521.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "521.04",
     "loan_balance_amount": "273572.84"
   },
@@ -364,7 +364,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "797.92",
     "principal_amount": "549.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "549.21",
     "loan_balance_amount": "273023.63"
   },
@@ -373,7 +373,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "796.32",
     "principal_amount": "550.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "550.81",
     "loan_balance_amount": "272472.82"
   },
@@ -382,7 +382,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "794.71",
     "principal_amount": "552.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "552.42",
     "loan_balance_amount": "271920.40"
   },
@@ -391,7 +391,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "793.10",
     "principal_amount": "554.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "554.03",
     "loan_balance_amount": "271366.37"
   },
@@ -400,7 +400,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "791.49",
     "principal_amount": "555.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "555.64",
     "loan_balance_amount": "270810.73"
   },
@@ -409,7 +409,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "789.86",
     "principal_amount": "557.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "557.27",
     "loan_balance_amount": "270253.46"
   },
@@ -418,7 +418,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "788.24",
     "principal_amount": "558.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "558.89",
     "loan_balance_amount": "269694.57"
   },
@@ -427,7 +427,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "786.61",
     "principal_amount": "560.52",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "560.52",
     "loan_balance_amount": "269134.05"
   },
@@ -436,7 +436,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "784.97",
     "principal_amount": "562.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "562.16",
     "loan_balance_amount": "268571.89"
   },
@@ -445,7 +445,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "783.33",
     "principal_amount": "563.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "563.80",
     "loan_balance_amount": "268008.09"
   },
@@ -454,7 +454,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "729.58",
     "principal_amount": "617.55",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "617.55",
     "loan_balance_amount": "267390.54"
   },
@@ -463,7 +463,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "831.88",
     "principal_amount": "515.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "515.25",
     "loan_balance_amount": "266875.29"
   },
@@ -472,7 +472,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "778.39",
     "principal_amount": "568.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "568.74",
     "loan_balance_amount": "266306.55"
   },
@@ -481,7 +481,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "776.73",
     "principal_amount": "570.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "570.40",
     "loan_balance_amount": "265736.15"
   },
@@ -490,7 +490,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "775.06",
     "principal_amount": "572.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "572.07",
     "loan_balance_amount": "265164.08"
   },
@@ -499,7 +499,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "773.40",
     "principal_amount": "573.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "573.73",
     "loan_balance_amount": "264590.35"
   },
@@ -508,7 +508,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "771.72",
     "principal_amount": "575.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "575.41",
     "loan_balance_amount": "264014.94"
   },
@@ -517,7 +517,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "770.04",
     "principal_amount": "577.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "577.09",
     "loan_balance_amount": "263437.85"
   },
@@ -526,7 +526,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "768.36",
     "principal_amount": "578.77",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "578.77",
     "loan_balance_amount": "262859.08"
   },
@@ -535,7 +535,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "766.67",
     "principal_amount": "580.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "580.46",
     "loan_balance_amount": "262278.62"
   },
@@ -544,7 +544,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "764.98",
     "principal_amount": "582.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "582.15",
     "loan_balance_amount": "261696.47"
   },
@@ -553,7 +553,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "763.28",
     "principal_amount": "583.85",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "583.85",
     "loan_balance_amount": "261112.62"
   },
@@ -562,7 +562,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "710.81",
     "principal_amount": "636.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "636.32",
     "loan_balance_amount": "260476.30"
   },
@@ -571,7 +571,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "810.37",
     "principal_amount": "536.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "536.76",
     "loan_balance_amount": "259939.54"
   },
@@ -580,7 +580,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "758.16",
     "principal_amount": "588.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "588.97",
     "loan_balance_amount": "259350.57"
   },
@@ -589,7 +589,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "756.44",
     "principal_amount": "590.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "590.69",
     "loan_balance_amount": "258759.88"
   },
@@ -598,7 +598,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "754.72",
     "principal_amount": "592.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "592.41",
     "loan_balance_amount": "258167.47"
   },
@@ -607,7 +607,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "752.99",
     "principal_amount": "594.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "594.14",
     "loan_balance_amount": "257573.33"
   },
@@ -616,7 +616,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "751.26",
     "principal_amount": "595.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "595.87",
     "loan_balance_amount": "256977.46"
   },
@@ -625,7 +625,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "749.52",
     "principal_amount": "597.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "597.61",
     "loan_balance_amount": "256379.85"
   },
@@ -634,7 +634,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "747.77",
     "principal_amount": "599.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "599.36",
     "loan_balance_amount": "255780.49"
   },
@@ -643,7 +643,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "746.03",
     "principal_amount": "601.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "601.10",
     "loan_balance_amount": "255179.39"
   },
@@ -652,7 +652,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "744.27",
     "principal_amount": "602.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "602.86",
     "loan_balance_amount": "254576.53"
   },
@@ -661,7 +661,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "742.51",
     "principal_amount": "604.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "604.62",
     "loan_balance_amount": "253971.91"
   },
@@ -670,7 +670,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "691.37",
     "principal_amount": "655.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "655.76",
     "loan_balance_amount": "253316.15"
   },
@@ -679,7 +679,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "788.09",
     "principal_amount": "559.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "559.04",
     "loan_balance_amount": "252757.11"
   },
@@ -688,7 +688,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "737.21",
     "principal_amount": "609.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "609.92",
     "loan_balance_amount": "252147.19"
   },
@@ -697,7 +697,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "735.43",
     "principal_amount": "611.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "611.70",
     "loan_balance_amount": "251535.49"
   },
@@ -706,7 +706,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "733.65",
     "principal_amount": "613.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "613.48",
     "loan_balance_amount": "250922.01"
   },
@@ -715,7 +715,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "731.86",
     "principal_amount": "615.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "615.27",
     "loan_balance_amount": "250306.74"
   },
@@ -724,7 +724,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "730.06",
     "principal_amount": "617.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "617.07",
     "loan_balance_amount": "249689.67"
   },
@@ -733,7 +733,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "728.26",
     "principal_amount": "618.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "618.87",
     "loan_balance_amount": "249070.80"
   },
@@ -742,7 +742,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "726.46",
     "principal_amount": "620.67",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "620.67",
     "loan_balance_amount": "248450.13"
   },
@@ -751,7 +751,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "724.65",
     "principal_amount": "622.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "622.48",
     "loan_balance_amount": "247827.65"
   },
@@ -760,7 +760,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "722.83",
     "principal_amount": "624.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "624.30",
     "loan_balance_amount": "247203.35"
   },
@@ -769,7 +769,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "721.01",
     "principal_amount": "626.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "626.12",
     "loan_balance_amount": "246577.23"
   },
@@ -778,7 +778,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "695.21",
     "principal_amount": "651.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "651.92",
     "loan_balance_amount": "245925.31"
   },
@@ -787,7 +787,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "741.19",
     "principal_amount": "605.94",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "605.94",
     "loan_balance_amount": "245319.37"
   },
@@ -796,7 +796,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "715.51",
     "principal_amount": "631.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "631.62",
     "loan_balance_amount": "244687.75"
   },
@@ -805,7 +805,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "713.67",
     "principal_amount": "633.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "633.46",
     "loan_balance_amount": "244054.29"
   },
@@ -814,7 +814,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "711.83",
     "principal_amount": "635.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "635.30",
     "loan_balance_amount": "243418.99"
   },
@@ -823,7 +823,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "709.97",
     "principal_amount": "637.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "637.16",
     "loan_balance_amount": "242781.83"
   },
@@ -832,7 +832,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "708.11",
     "principal_amount": "639.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "639.02",
     "loan_balance_amount": "242142.81"
   },
@@ -841,7 +841,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "706.25",
     "principal_amount": "640.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "640.88",
     "loan_balance_amount": "241501.93"
   },
@@ -850,7 +850,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "704.38",
     "principal_amount": "642.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "642.75",
     "loan_balance_amount": "240859.18"
   },
@@ -859,7 +859,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "702.51",
     "principal_amount": "644.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "644.62",
     "loan_balance_amount": "240214.56"
   },
@@ -868,7 +868,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "700.63",
     "principal_amount": "646.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "646.50",
     "loan_balance_amount": "239568.06"
   },
@@ -877,7 +877,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "698.74",
     "principal_amount": "648.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "648.39",
     "loan_balance_amount": "238919.67"
   },
@@ -886,7 +886,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "650.39",
     "principal_amount": "696.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "696.74",
     "loan_balance_amount": "238222.93"
   },
@@ -895,7 +895,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "741.14",
     "principal_amount": "605.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "605.99",
     "loan_balance_amount": "237616.94"
   },
@@ -904,7 +904,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "693.05",
     "principal_amount": "654.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "654.08",
     "loan_balance_amount": "236962.86"
   },
@@ -913,7 +913,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "691.14",
     "principal_amount": "655.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "655.99",
     "loan_balance_amount": "236306.87"
   },
@@ -922,7 +922,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "689.23",
     "principal_amount": "657.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "657.90",
     "loan_balance_amount": "235648.97"
   },
@@ -931,7 +931,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "687.31",
     "principal_amount": "659.82",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "659.82",
     "loan_balance_amount": "234989.15"
   },
@@ -940,7 +940,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "685.39",
     "principal_amount": "661.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "661.74",
     "loan_balance_amount": "234327.41"
   },
@@ -949,7 +949,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "683.45",
     "principal_amount": "663.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "663.68",
     "loan_balance_amount": "233663.73"
   },
@@ -958,7 +958,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "681.52",
     "principal_amount": "665.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "665.61",
     "loan_balance_amount": "232998.12"
   },
@@ -967,7 +967,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "679.58",
     "principal_amount": "667.55",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "667.55",
     "loan_balance_amount": "232330.57"
   },
@@ -976,7 +976,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "677.63",
     "principal_amount": "669.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "669.50",
     "loan_balance_amount": "231661.07"
   },
@@ -985,7 +985,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "675.68",
     "principal_amount": "671.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "671.45",
     "loan_balance_amount": "230989.62"
   },
@@ -994,7 +994,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "628.81",
     "principal_amount": "718.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "718.32",
     "loan_balance_amount": "230271.30"
   },
@@ -1003,7 +1003,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "716.40",
     "principal_amount": "630.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "630.73",
     "loan_balance_amount": "229640.57"
   },
@@ -1012,7 +1012,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "669.78",
     "principal_amount": "677.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "677.35",
     "loan_balance_amount": "228963.22"
   },
@@ -1021,7 +1021,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "667.81",
     "principal_amount": "679.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "679.32",
     "loan_balance_amount": "228283.90"
   },
@@ -1030,7 +1030,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "665.83",
     "principal_amount": "681.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "681.30",
     "loan_balance_amount": "227602.60"
   },
@@ -1039,7 +1039,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "663.84",
     "principal_amount": "683.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "683.29",
     "loan_balance_amount": "226919.31"
   },
@@ -1048,7 +1048,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "661.85",
     "principal_amount": "685.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "685.28",
     "loan_balance_amount": "226234.03"
   },
@@ -1057,7 +1057,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "659.85",
     "principal_amount": "687.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "687.28",
     "loan_balance_amount": "225546.75"
   },
@@ -1066,7 +1066,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "657.84",
     "principal_amount": "689.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "689.29",
     "loan_balance_amount": "224857.46"
   },
@@ -1075,7 +1075,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "655.83",
     "principal_amount": "691.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "691.30",
     "loan_balance_amount": "224166.16"
   },
@@ -1084,7 +1084,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "653.82",
     "principal_amount": "693.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "693.31",
     "loan_balance_amount": "223472.85"
   },
@@ -1093,7 +1093,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "651.80",
     "principal_amount": "695.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "695.33",
     "loan_balance_amount": "222777.52"
   },
@@ -1102,7 +1102,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "606.45",
     "principal_amount": "740.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "740.68",
     "loan_balance_amount": "222036.84"
   },
@@ -1111,7 +1111,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "690.78",
     "principal_amount": "656.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "656.35",
     "loan_balance_amount": "221380.49"
   },
@@ -1120,7 +1120,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "645.69",
     "principal_amount": "701.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "701.44",
     "loan_balance_amount": "220679.05"
   },
@@ -1129,7 +1129,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "643.65",
     "principal_amount": "703.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "703.48",
     "loan_balance_amount": "219975.57"
   },
@@ -1138,7 +1138,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "641.60",
     "principal_amount": "705.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "705.53",
     "loan_balance_amount": "219270.04"
   },
@@ -1147,7 +1147,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "639.54",
     "principal_amount": "707.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "707.59",
     "loan_balance_amount": "218562.45"
   },
@@ -1156,7 +1156,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "637.47",
     "principal_amount": "709.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "709.66",
     "loan_balance_amount": "217852.79"
   },
@@ -1165,7 +1165,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "635.40",
     "principal_amount": "711.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "711.73",
     "loan_balance_amount": "217141.06"
   },
@@ -1174,7 +1174,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "633.33",
     "principal_amount": "713.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "713.80",
     "loan_balance_amount": "216427.26"
   },
@@ -1183,7 +1183,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "631.25",
     "principal_amount": "715.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "715.88",
     "loan_balance_amount": "215711.38"
   },
@@ -1192,7 +1192,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "629.16",
     "principal_amount": "717.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "717.97",
     "loan_balance_amount": "214993.41"
   },
@@ -1201,7 +1201,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "627.06",
     "principal_amount": "720.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "720.07",
     "loan_balance_amount": "214273.34"
   },
@@ -1210,7 +1210,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "604.13",
     "principal_amount": "743.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "743.00",
     "loan_balance_amount": "213530.34"
   },
@@ -1219,7 +1219,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "643.56",
     "principal_amount": "703.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "703.57",
     "loan_balance_amount": "212826.77"
   },
@@ -1228,7 +1228,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "620.74",
     "principal_amount": "726.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "726.39",
     "loan_balance_amount": "212100.38"
   },
@@ -1237,7 +1237,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "618.63",
     "principal_amount": "728.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "728.50",
     "loan_balance_amount": "211371.88"
   },
@@ -1246,7 +1246,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "616.50",
     "principal_amount": "730.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "730.63",
     "loan_balance_amount": "210641.25"
   },
@@ -1255,7 +1255,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "614.37",
     "principal_amount": "732.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "732.76",
     "loan_balance_amount": "209908.49"
   },
@@ -1264,7 +1264,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "612.23",
     "principal_amount": "734.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "734.90",
     "loan_balance_amount": "209173.59"
   },
@@ -1273,7 +1273,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "610.09",
     "principal_amount": "737.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "737.04",
     "loan_balance_amount": "208436.55"
   },
@@ -1282,7 +1282,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "607.94",
     "principal_amount": "739.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "739.19",
     "loan_balance_amount": "207697.36"
   },
@@ -1291,7 +1291,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "605.78",
     "principal_amount": "741.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "741.35",
     "loan_balance_amount": "206956.01"
   },
@@ -1300,7 +1300,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "603.62",
     "principal_amount": "743.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "743.51",
     "loan_balance_amount": "206212.50"
   },
@@ -1309,7 +1309,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "601.45",
     "principal_amount": "745.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "745.68",
     "loan_balance_amount": "205466.82"
   },
@@ -1318,7 +1318,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "559.33",
     "principal_amount": "787.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "787.80",
     "loan_balance_amount": "204679.02"
   },
@@ -1327,7 +1327,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "636.78",
     "principal_amount": "710.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "710.35",
     "loan_balance_amount": "203968.67"
   },
@@ -1336,7 +1336,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "594.91",
     "principal_amount": "752.22",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "752.22",
     "loan_balance_amount": "203216.45"
   },
@@ -1345,7 +1345,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "592.71",
     "principal_amount": "754.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "754.42",
     "loan_balance_amount": "202462.03"
   },
@@ -1354,7 +1354,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "590.51",
     "principal_amount": "756.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "756.62",
     "loan_balance_amount": "201705.41"
   },
@@ -1363,7 +1363,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "588.31",
     "principal_amount": "758.82",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "758.82",
     "loan_balance_amount": "200946.59"
   },
@@ -1372,7 +1372,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "586.09",
     "principal_amount": "761.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "761.04",
     "loan_balance_amount": "200185.55"
   },
@@ -1381,7 +1381,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "583.87",
     "principal_amount": "763.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "763.26",
     "loan_balance_amount": "199422.29"
   },
@@ -1390,7 +1390,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "581.65",
     "principal_amount": "765.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "765.48",
     "loan_balance_amount": "198656.81"
   },
@@ -1399,7 +1399,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "579.42",
     "principal_amount": "767.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "767.71",
     "loan_balance_amount": "197889.10"
   },
@@ -1408,7 +1408,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "577.18",
     "principal_amount": "769.95",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "769.95",
     "loan_balance_amount": "197119.15"
   },
@@ -1417,7 +1417,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "574.93",
     "principal_amount": "772.20",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "772.20",
     "loan_balance_amount": "196346.95"
   },
@@ -1426,7 +1426,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "534.50",
     "principal_amount": "812.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "812.63",
     "loan_balance_amount": "195534.32"
   },
@@ -1435,7 +1435,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "608.33",
     "principal_amount": "738.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "738.80",
     "loan_balance_amount": "194795.52"
   },
@@ -1444,7 +1444,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "568.15",
     "principal_amount": "778.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "778.98",
     "loan_balance_amount": "194016.54"
   },
@@ -1453,7 +1453,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "565.88",
     "principal_amount": "781.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "781.25",
     "loan_balance_amount": "193235.29"
   },
@@ -1462,7 +1462,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "563.60",
     "principal_amount": "783.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "783.53",
     "loan_balance_amount": "192451.76"
   },
@@ -1471,7 +1471,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "561.32",
     "principal_amount": "785.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "785.81",
     "loan_balance_amount": "191665.95"
   },
@@ -1480,7 +1480,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "559.03",
     "principal_amount": "788.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "788.10",
     "loan_balance_amount": "190877.85"
   },
@@ -1489,7 +1489,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "556.73",
     "principal_amount": "790.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "790.40",
     "loan_balance_amount": "190087.45"
   },
@@ -1498,7 +1498,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "554.42",
     "principal_amount": "792.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "792.71",
     "loan_balance_amount": "189294.74"
   },
@@ -1507,7 +1507,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "552.11",
     "principal_amount": "795.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "795.02",
     "loan_balance_amount": "188499.72"
   },
@@ -1516,7 +1516,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "549.79",
     "principal_amount": "797.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "797.34",
     "loan_balance_amount": "187702.38"
   },
@@ -1525,7 +1525,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "547.47",
     "principal_amount": "799.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "799.66",
     "loan_balance_amount": "186902.72"
   },
@@ -1534,7 +1534,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "508.79",
     "principal_amount": "838.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "838.34",
     "loan_balance_amount": "186064.38"
   },
@@ -1543,7 +1543,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "578.87",
     "principal_amount": "768.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "768.26",
     "loan_balance_amount": "185296.12"
   },
@@ -1552,7 +1552,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "540.45",
     "principal_amount": "806.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "806.68",
     "loan_balance_amount": "184489.44"
   },
@@ -1561,7 +1561,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "538.09",
     "principal_amount": "809.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "809.04",
     "loan_balance_amount": "183680.40"
   },
@@ -1570,7 +1570,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "535.73",
     "principal_amount": "811.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "811.40",
     "loan_balance_amount": "182869.00"
   },
@@ -1579,7 +1579,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "533.37",
     "principal_amount": "813.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "813.76",
     "loan_balance_amount": "182055.24"
   },
@@ -1588,7 +1588,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "530.99",
     "principal_amount": "816.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "816.14",
     "loan_balance_amount": "181239.10"
   },
@@ -1597,7 +1597,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "528.61",
     "principal_amount": "818.52",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "818.52",
     "loan_balance_amount": "180420.58"
   },
@@ -1606,7 +1606,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "526.23",
     "principal_amount": "820.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "820.90",
     "loan_balance_amount": "179599.68"
   },
@@ -1615,7 +1615,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "523.83",
     "principal_amount": "823.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "823.30",
     "loan_balance_amount": "178776.38"
   },
@@ -1624,7 +1624,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "521.43",
     "principal_amount": "825.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "825.70",
     "loan_balance_amount": "177950.68"
   },
@@ -1633,7 +1633,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "519.02",
     "principal_amount": "828.11",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "828.11",
     "loan_balance_amount": "177122.57"
   },
@@ -1642,7 +1642,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "499.39",
     "principal_amount": "847.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "847.74",
     "loan_balance_amount": "176274.83"
   },
@@ -1651,7 +1651,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "531.27",
     "principal_amount": "815.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "815.86",
     "loan_balance_amount": "175458.97"
   },
@@ -1660,7 +1660,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "511.76",
     "principal_amount": "835.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "835.37",
     "loan_balance_amount": "174623.60"
   },
@@ -1669,7 +1669,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "509.32",
     "principal_amount": "837.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "837.81",
     "loan_balance_amount": "173785.79"
   },
@@ -1678,7 +1678,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "506.88",
     "principal_amount": "840.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "840.25",
     "loan_balance_amount": "172945.54"
   },
@@ -1687,7 +1687,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "504.42",
     "principal_amount": "842.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "842.71",
     "loan_balance_amount": "172102.83"
   },
@@ -1696,7 +1696,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "501.97",
     "principal_amount": "845.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "845.16",
     "loan_balance_amount": "171257.67"
   },
@@ -1705,7 +1705,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "499.50",
     "principal_amount": "847.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "847.63",
     "loan_balance_amount": "170410.04"
   },
@@ -1714,7 +1714,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "497.03",
     "principal_amount": "850.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "850.10",
     "loan_balance_amount": "169559.94"
   },
@@ -1723,7 +1723,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "494.55",
     "principal_amount": "852.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "852.58",
     "loan_balance_amount": "168707.36"
   },
@@ -1732,7 +1732,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "492.06",
     "principal_amount": "855.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "855.07",
     "loan_balance_amount": "167852.29"
   },
@@ -1741,7 +1741,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "489.57",
     "principal_amount": "857.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "857.56",
     "loan_balance_amount": "166994.73"
   },
@@ -1750,7 +1750,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "454.60",
     "principal_amount": "892.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "892.53",
     "loan_balance_amount": "166102.20"
   },
@@ -1759,7 +1759,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "516.76",
     "principal_amount": "830.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "830.37",
     "loan_balance_amount": "165271.83"
   },
@@ -1768,7 +1768,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "482.04",
     "principal_amount": "865.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "865.09",
     "loan_balance_amount": "164406.74"
   },
@@ -1777,7 +1777,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "479.52",
     "principal_amount": "867.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "867.61",
     "loan_balance_amount": "163539.13"
   },
@@ -1786,7 +1786,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "476.99",
     "principal_amount": "870.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "870.14",
     "loan_balance_amount": "162668.99"
   },
@@ -1795,7 +1795,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "474.45",
     "principal_amount": "872.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "872.68",
     "loan_balance_amount": "161796.31"
   },
@@ -1804,7 +1804,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "471.91",
     "principal_amount": "875.22",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "875.22",
     "loan_balance_amount": "160921.09"
   },
@@ -1813,7 +1813,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "469.35",
     "principal_amount": "877.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "877.78",
     "loan_balance_amount": "160043.31"
   },
@@ -1822,7 +1822,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "466.79",
     "principal_amount": "880.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "880.34",
     "loan_balance_amount": "159162.97"
   },
@@ -1831,7 +1831,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "464.23",
     "principal_amount": "882.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "882.90",
     "loan_balance_amount": "158280.07"
   },
@@ -1840,7 +1840,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "461.65",
     "principal_amount": "885.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "885.48",
     "loan_balance_amount": "157394.59"
   },
@@ -1849,7 +1849,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "459.07",
     "principal_amount": "888.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "888.06",
     "loan_balance_amount": "156506.53"
   },
@@ -1858,7 +1858,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "426.05",
     "principal_amount": "921.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "921.08",
     "loan_balance_amount": "155585.45"
   },
@@ -1867,7 +1867,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "484.04",
     "principal_amount": "863.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "863.09",
     "loan_balance_amount": "154722.36"
   },
@@ -1876,7 +1876,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "451.27",
     "principal_amount": "895.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "895.86",
     "loan_balance_amount": "153826.50"
   },
@@ -1885,7 +1885,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "448.66",
     "principal_amount": "898.47",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "898.47",
     "loan_balance_amount": "152928.03"
   },
@@ -1894,7 +1894,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "446.04",
     "principal_amount": "901.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "901.09",
     "loan_balance_amount": "152026.94"
   },
@@ -1903,7 +1903,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "443.41",
     "principal_amount": "903.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "903.72",
     "loan_balance_amount": "151123.22"
   },
@@ -1912,7 +1912,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "440.78",
     "principal_amount": "906.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "906.35",
     "loan_balance_amount": "150216.87"
   },
@@ -1921,7 +1921,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "438.13",
     "principal_amount": "909.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "909.00",
     "loan_balance_amount": "149307.87"
   },
@@ -1930,7 +1930,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "435.48",
     "principal_amount": "911.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "911.65",
     "loan_balance_amount": "148396.22"
   },
@@ -1939,7 +1939,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "432.82",
     "principal_amount": "914.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "914.31",
     "loan_balance_amount": "147481.91"
   },
@@ -1948,7 +1948,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "430.16",
     "principal_amount": "916.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "916.97",
     "loan_balance_amount": "146564.94"
   },
@@ -1957,7 +1957,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "427.48",
     "principal_amount": "919.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "919.65",
     "loan_balance_amount": "145645.29"
   },
@@ -1966,7 +1966,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "396.48",
     "principal_amount": "950.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "950.65",
     "loan_balance_amount": "144694.64"
   },
@@ -1975,7 +1975,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "450.16",
     "principal_amount": "896.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "896.97",
     "loan_balance_amount": "143797.67"
   },
@@ -1984,7 +1984,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "419.41",
     "principal_amount": "927.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "927.72",
     "loan_balance_amount": "142869.95"
   },
@@ -1993,7 +1993,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "416.70",
     "principal_amount": "930.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "930.43",
     "loan_balance_amount": "141939.52"
   },
@@ -2002,7 +2002,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "413.99",
     "principal_amount": "933.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "933.14",
     "loan_balance_amount": "141006.38"
   },
@@ -2011,7 +2011,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "411.27",
     "principal_amount": "935.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "935.86",
     "loan_balance_amount": "140070.52"
   },
@@ -2020,7 +2020,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "408.54",
     "principal_amount": "938.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "938.59",
     "loan_balance_amount": "139131.93"
   },
@@ -2029,7 +2029,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "405.80",
     "principal_amount": "941.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "941.33",
     "loan_balance_amount": "138190.60"
   },
@@ -2038,7 +2038,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "403.06",
     "principal_amount": "944.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "944.07",
     "loan_balance_amount": "137246.53"
   },
@@ -2047,7 +2047,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "400.30",
     "principal_amount": "946.83",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "946.83",
     "loan_balance_amount": "136299.70"
   },
@@ -2056,7 +2056,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "397.54",
     "principal_amount": "949.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "949.59",
     "loan_balance_amount": "135350.11"
   },
@@ -2065,7 +2065,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "394.77",
     "principal_amount": "952.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "952.36",
     "loan_balance_amount": "134397.75"
   },
@@ -2074,7 +2074,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "378.93",
     "principal_amount": "968.20",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "968.20",
     "loan_balance_amount": "133429.55"
   },
@@ -2083,7 +2083,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "402.14",
     "principal_amount": "944.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "944.99",
     "loan_balance_amount": "132484.56"
   },
@@ -2092,7 +2092,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "386.41",
     "principal_amount": "960.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "960.72",
     "loan_balance_amount": "131523.84"
   },
@@ -2101,7 +2101,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "383.61",
     "principal_amount": "963.52",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "963.52",
     "loan_balance_amount": "130560.32"
   },
@@ -2110,7 +2110,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "380.80",
     "principal_amount": "966.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "966.33",
     "loan_balance_amount": "129593.99"
   },
@@ -2119,7 +2119,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "377.98",
     "principal_amount": "969.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "969.15",
     "loan_balance_amount": "128624.84"
   },
@@ -2128,7 +2128,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "375.16",
     "principal_amount": "971.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "971.97",
     "loan_balance_amount": "127652.87"
   },
@@ -2137,7 +2137,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "372.32",
     "principal_amount": "974.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "974.81",
     "loan_balance_amount": "126678.06"
   },
@@ -2146,7 +2146,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "369.48",
     "principal_amount": "977.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "977.65",
     "loan_balance_amount": "125700.41"
   },
@@ -2155,7 +2155,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "366.63",
     "principal_amount": "980.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "980.50",
     "loan_balance_amount": "124719.91"
   },
@@ -2164,7 +2164,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "363.77",
     "principal_amount": "983.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "983.36",
     "loan_balance_amount": "123736.55"
   },
@@ -2173,7 +2173,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "360.90",
     "principal_amount": "986.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "986.23",
     "loan_balance_amount": "122750.32"
   },
@@ -2182,7 +2182,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "334.15",
     "principal_amount": "1012.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1012.98",
     "loan_balance_amount": "121737.34"
   },
@@ -2191,7 +2191,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "378.74",
     "principal_amount": "968.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "968.39",
     "loan_balance_amount": "120768.95"
   },
@@ -2200,7 +2200,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "352.24",
     "principal_amount": "994.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "994.89",
     "loan_balance_amount": "119774.06"
   },
@@ -2209,7 +2209,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "349.34",
     "principal_amount": "997.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "997.79",
     "loan_balance_amount": "118776.27"
   },
@@ -2218,7 +2218,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "346.43",
     "principal_amount": "1000.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1000.70",
     "loan_balance_amount": "117775.57"
   },
@@ -2227,7 +2227,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "343.51",
     "principal_amount": "1003.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1003.62",
     "loan_balance_amount": "116771.95"
   },
@@ -2236,7 +2236,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "340.58",
     "principal_amount": "1006.55",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1006.55",
     "loan_balance_amount": "115765.40"
   },
@@ -2245,7 +2245,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "337.65",
     "principal_amount": "1009.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1009.48",
     "loan_balance_amount": "114755.92"
   },
@@ -2254,7 +2254,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "334.70",
     "principal_amount": "1012.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1012.43",
     "loan_balance_amount": "113743.49"
   },
@@ -2263,7 +2263,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "331.75",
     "principal_amount": "1015.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1015.38",
     "loan_balance_amount": "112728.11"
   },
@@ -2272,7 +2272,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "328.79",
     "principal_amount": "1018.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1018.34",
     "loan_balance_amount": "111709.77"
   },
@@ -2281,7 +2281,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "325.82",
     "principal_amount": "1021.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1021.31",
     "loan_balance_amount": "110688.46"
   },
@@ -2290,7 +2290,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "301.32",
     "principal_amount": "1045.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1045.81",
     "loan_balance_amount": "109642.65"
   },
@@ -2299,7 +2299,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "341.11",
     "principal_amount": "1006.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1006.02",
     "loan_balance_amount": "108636.63"
   },
@@ -2308,7 +2308,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "316.86",
     "principal_amount": "1030.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1030.27",
     "loan_balance_amount": "107606.36"
   },
@@ -2317,7 +2317,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "313.85",
     "principal_amount": "1033.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1033.28",
     "loan_balance_amount": "106573.08"
   },
@@ -2326,7 +2326,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "310.84",
     "principal_amount": "1036.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1036.29",
     "loan_balance_amount": "105536.79"
   },
@@ -2335,7 +2335,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "307.82",
     "principal_amount": "1039.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1039.31",
     "loan_balance_amount": "104497.48"
   },
@@ -2344,7 +2344,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "304.78",
     "principal_amount": "1042.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1042.35",
     "loan_balance_amount": "103455.13"
   },
@@ -2353,7 +2353,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "301.74",
     "principal_amount": "1045.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1045.39",
     "loan_balance_amount": "102409.74"
   },
@@ -2362,7 +2362,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "298.70",
     "principal_amount": "1048.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1048.43",
     "loan_balance_amount": "101361.31"
   },
@@ -2371,7 +2371,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "295.64",
     "principal_amount": "1051.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1051.49",
     "loan_balance_amount": "100309.82"
   },
@@ -2380,7 +2380,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "292.57",
     "principal_amount": "1054.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1054.56",
     "loan_balance_amount": "99255.26"
   },
@@ -2389,7 +2389,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "289.49",
     "principal_amount": "1057.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1057.64",
     "loan_balance_amount": "98197.62"
   },
@@ -2398,7 +2398,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "267.32",
     "principal_amount": "1079.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1079.81",
     "loan_balance_amount": "97117.81"
   },
@@ -2407,7 +2407,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "302.14",
     "principal_amount": "1044.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1044.99",
     "loan_balance_amount": "96072.82"
   },
@@ -2416,7 +2416,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "280.21",
     "principal_amount": "1066.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1066.92",
     "loan_balance_amount": "95005.90"
   },
@@ -2425,7 +2425,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "277.10",
     "principal_amount": "1070.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1070.03",
     "loan_balance_amount": "93935.87"
   },
@@ -2434,7 +2434,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "273.98",
     "principal_amount": "1073.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1073.15",
     "loan_balance_amount": "92862.72"
   },
@@ -2443,7 +2443,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "270.85",
     "principal_amount": "1076.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1076.28",
     "loan_balance_amount": "91786.44"
   },
@@ -2452,7 +2452,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "267.71",
     "principal_amount": "1079.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1079.42",
     "loan_balance_amount": "90707.02"
   },
@@ -2461,7 +2461,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "264.56",
     "principal_amount": "1082.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1082.57",
     "loan_balance_amount": "89624.45"
   },
@@ -2470,7 +2470,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "261.40",
     "principal_amount": "1085.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1085.73",
     "loan_balance_amount": "88538.72"
   },
@@ -2479,7 +2479,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "258.24",
     "principal_amount": "1088.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1088.89",
     "loan_balance_amount": "87449.83"
   },
@@ -2488,7 +2488,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "255.06",
     "principal_amount": "1092.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1092.07",
     "loan_balance_amount": "86357.76"
   },
@@ -2497,7 +2497,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "251.88",
     "principal_amount": "1095.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1095.25",
     "loan_balance_amount": "85262.51"
   },
@@ -2506,7 +2506,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "240.39",
     "principal_amount": "1106.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1106.74",
     "loan_balance_amount": "84155.77"
   },
@@ -2515,7 +2515,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "253.64",
     "principal_amount": "1093.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1093.49",
     "loan_balance_amount": "83062.28"
   },
@@ -2524,7 +2524,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "242.26",
     "principal_amount": "1104.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1104.87",
     "loan_balance_amount": "81957.41"
   },
@@ -2533,7 +2533,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "239.04",
     "principal_amount": "1108.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1108.09",
     "loan_balance_amount": "80849.32"
   },
@@ -2542,7 +2542,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "235.81",
     "principal_amount": "1111.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1111.32",
     "loan_balance_amount": "79738.00"
   },
@@ -2551,7 +2551,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "232.57",
     "principal_amount": "1114.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1114.56",
     "loan_balance_amount": "78623.44"
   },
@@ -2560,7 +2560,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "229.32",
     "principal_amount": "1117.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1117.81",
     "loan_balance_amount": "77505.63"
   },
@@ -2569,7 +2569,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "226.06",
     "principal_amount": "1121.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1121.07",
     "loan_balance_amount": "76384.56"
   },
@@ -2578,7 +2578,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "222.79",
     "principal_amount": "1124.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1124.34",
     "loan_balance_amount": "75260.22"
   },
@@ -2587,7 +2587,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "219.51",
     "principal_amount": "1127.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1127.62",
     "loan_balance_amount": "74132.60"
   },
@@ -2596,7 +2596,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "216.22",
     "principal_amount": "1130.91",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1130.91",
     "loan_balance_amount": "73001.69"
   },
@@ -2605,7 +2605,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "212.92",
     "principal_amount": "1134.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1134.21",
     "loan_balance_amount": "71867.48"
   },
@@ -2614,7 +2614,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "195.64",
     "principal_amount": "1151.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1151.49",
     "loan_balance_amount": "70715.99"
   },
@@ -2623,7 +2623,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "220.01",
     "principal_amount": "1127.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1127.12",
     "loan_balance_amount": "69588.87"
   },
@@ -2632,7 +2632,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "202.97",
     "principal_amount": "1144.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1144.16",
     "loan_balance_amount": "68444.71"
   },
@@ -2641,7 +2641,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "199.63",
     "principal_amount": "1147.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1147.50",
     "loan_balance_amount": "67297.21"
   },
@@ -2650,7 +2650,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "196.28",
     "principal_amount": "1150.85",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1150.85",
     "loan_balance_amount": "66146.36"
   },
@@ -2659,7 +2659,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "192.93",
     "principal_amount": "1154.20",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1154.20",
     "loan_balance_amount": "64992.16"
   },
@@ -2668,7 +2668,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "189.56",
     "principal_amount": "1157.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1157.57",
     "loan_balance_amount": "63834.59"
   },
@@ -2677,7 +2677,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "186.18",
     "principal_amount": "1160.95",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1160.95",
     "loan_balance_amount": "62673.64"
   },
@@ -2686,7 +2686,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "182.80",
     "principal_amount": "1164.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1164.33",
     "loan_balance_amount": "61509.31"
   },
@@ -2695,7 +2695,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "179.40",
     "principal_amount": "1167.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1167.73",
     "loan_balance_amount": "60341.58"
   },
@@ -2704,7 +2704,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "176.00",
     "principal_amount": "1171.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1171.13",
     "loan_balance_amount": "59170.45"
   },
@@ -2713,7 +2713,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "172.58",
     "principal_amount": "1174.55",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1174.55",
     "loan_balance_amount": "57995.90"
   },
@@ -2722,7 +2722,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "157.88",
     "principal_amount": "1189.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1189.25",
     "loan_balance_amount": "56806.65"
   },
@@ -2731,7 +2731,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "176.73",
     "principal_amount": "1170.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1170.40",
     "loan_balance_amount": "55636.25"
   },
@@ -2740,7 +2740,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "162.27",
     "principal_amount": "1184.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1184.86",
     "loan_balance_amount": "54451.39"
   },
@@ -2749,7 +2749,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "158.82",
     "principal_amount": "1188.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1188.31",
     "loan_balance_amount": "53263.08"
   },
@@ -2758,7 +2758,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "155.35",
     "principal_amount": "1191.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1191.78",
     "loan_balance_amount": "52071.30"
   },
@@ -2767,7 +2767,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "151.87",
     "principal_amount": "1195.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1195.26",
     "loan_balance_amount": "50876.04"
   },
@@ -2776,7 +2776,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "148.39",
     "principal_amount": "1198.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1198.74",
     "loan_balance_amount": "49677.30"
   },
@@ -2785,7 +2785,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "144.89",
     "principal_amount": "1202.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1202.24",
     "loan_balance_amount": "48475.06"
   },
@@ -2794,7 +2794,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "141.39",
     "principal_amount": "1205.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1205.74",
     "loan_balance_amount": "47269.32"
   },
@@ -2803,7 +2803,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "137.87",
     "principal_amount": "1209.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1209.26",
     "loan_balance_amount": "46060.06"
   },
@@ -2812,7 +2812,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "134.34",
     "principal_amount": "1212.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1212.79",
     "loan_balance_amount": "44847.27"
   },
@@ -2821,7 +2821,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "130.80",
     "principal_amount": "1216.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1216.33",
     "loan_balance_amount": "43630.94"
   },
@@ -2830,7 +2830,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "118.77",
     "principal_amount": "1228.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1228.36",
     "loan_balance_amount": "42402.58"
   },
@@ -2839,7 +2839,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "131.92",
     "principal_amount": "1215.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1215.21",
     "loan_balance_amount": "41187.37"
   },
@@ -2848,7 +2848,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "120.13",
     "principal_amount": "1227.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1227.00",
     "loan_balance_amount": "39960.37"
   },
@@ -2857,7 +2857,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "116.55",
     "principal_amount": "1230.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1230.58",
     "loan_balance_amount": "38729.79"
   },
@@ -2866,7 +2866,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "112.96",
     "principal_amount": "1234.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1234.17",
     "loan_balance_amount": "37495.62"
   },
@@ -2875,7 +2875,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "109.36",
     "principal_amount": "1237.77",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1237.77",
     "loan_balance_amount": "36257.85"
   },
@@ -2884,7 +2884,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "105.75",
     "principal_amount": "1241.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1241.38",
     "loan_balance_amount": "35016.47"
   },
@@ -2893,7 +2893,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "102.13",
     "principal_amount": "1245.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1245.00",
     "loan_balance_amount": "33771.47"
   },
@@ -2902,7 +2902,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "98.50",
     "principal_amount": "1248.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1248.63",
     "loan_balance_amount": "32522.84"
   },
@@ -2911,7 +2911,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "94.86",
     "principal_amount": "1252.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1252.27",
     "loan_balance_amount": "31270.57"
   },
@@ -2920,7 +2920,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "91.21",
     "principal_amount": "1255.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1255.92",
     "loan_balance_amount": "30014.65"
   },
@@ -2929,7 +2929,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "87.54",
     "principal_amount": "1259.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1259.59",
     "loan_balance_amount": "28755.06"
   },
@@ -2938,7 +2938,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "81.07",
     "principal_amount": "1266.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1266.06",
     "loan_balance_amount": "27489.00"
   },
@@ -2947,7 +2947,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "82.85",
     "principal_amount": "1264.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1264.28",
     "loan_balance_amount": "26224.72"
   },
@@ -2956,7 +2956,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "76.49",
     "principal_amount": "1270.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1270.64",
     "loan_balance_amount": "24954.08"
   },
@@ -2965,7 +2965,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "72.78",
     "principal_amount": "1274.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1274.35",
     "loan_balance_amount": "23679.73"
   },
@@ -2974,7 +2974,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "69.07",
     "principal_amount": "1278.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1278.06",
     "loan_balance_amount": "22401.67"
   },
@@ -2983,7 +2983,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "65.34",
     "principal_amount": "1281.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1281.79",
     "loan_balance_amount": "21119.88"
   },
@@ -2992,7 +2992,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "61.60",
     "principal_amount": "1285.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1285.53",
     "loan_balance_amount": "19834.35"
   },
@@ -3001,7 +3001,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "57.85",
     "principal_amount": "1289.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1289.28",
     "loan_balance_amount": "18545.07"
   },
@@ -3010,7 +3010,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "54.09",
     "principal_amount": "1293.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1293.04",
     "loan_balance_amount": "17252.03"
   },
@@ -3019,7 +3019,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "50.32",
     "principal_amount": "1296.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1296.81",
     "loan_balance_amount": "15955.22"
   },
@@ -3028,7 +3028,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "46.54",
     "principal_amount": "1300.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1300.59",
     "loan_balance_amount": "14654.63"
   },
@@ -3037,7 +3037,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "42.74",
     "principal_amount": "1304.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1304.39",
     "loan_balance_amount": "13350.24"
   },
@@ -3046,7 +3046,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "36.34",
     "principal_amount": "1310.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1310.79",
     "loan_balance_amount": "12039.45"
   },
@@ -3055,7 +3055,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "37.46",
     "principal_amount": "1309.67",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1309.67",
     "loan_balance_amount": "10729.78"
   },
@@ -3064,7 +3064,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "31.30",
     "principal_amount": "1315.83",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1315.83",
     "loan_balance_amount": "9413.95"
   },
@@ -3073,7 +3073,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "27.46",
     "principal_amount": "1319.67",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1319.67",
     "loan_balance_amount": "8094.28"
   },
@@ -3082,7 +3082,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "23.61",
     "principal_amount": "1323.52",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1323.52",
     "loan_balance_amount": "6770.76"
   },
@@ -3091,7 +3091,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "19.75",
     "principal_amount": "1327.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1327.38",
     "loan_balance_amount": "5443.38"
   },
@@ -3100,7 +3100,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "15.88",
     "principal_amount": "1331.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1331.25",
     "loan_balance_amount": "4112.13"
   },
@@ -3109,7 +3109,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "11.99",
     "principal_amount": "1335.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1335.14",
     "loan_balance_amount": "2776.99"
   },
@@ -3118,7 +3118,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "8.10",
     "principal_amount": "1339.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1339.03",
     "loan_balance_amount": "1437.96"
   },
@@ -3127,7 +3127,7 @@
     "payment_amount": "1347.13",
     "interest_amount": "4.19",
     "principal_amount": "1342.94",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1342.94",
     "loan_balance_amount": "95.02"
   },
@@ -3136,7 +3136,7 @@
     "payment_amount": "95.30",
     "interest_amount": "0.28",
     "principal_amount": "95.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "95.02",
     "loan_balance_amount": "0.00"
   }

--- a/tests/snapshots/linear_loan_with_interest_only.json
+++ b/tests/snapshots/linear_loan_with_interest_only.json
@@ -12,36 +12,36 @@
     "date": "2023-06-30T00:00:00",
     "payment_amount": "281.25",
     "interest_amount": "281.25",
-    "principal_amount": "0",
-    "special_principal_amount": "0",
-    "total_principal_amount": "0",
+    "principal_amount": "0.00",
+    "special_principal_amount": "0.00",
+    "total_principal_amount": "0.00",
     "loan_balance_amount": "150000.00"
   },
   {
     "date": "2023-09-30T00:00:00",
     "payment_amount": "1687.50",
     "interest_amount": "1687.50",
-    "principal_amount": "0",
-    "special_principal_amount": "0",
-    "total_principal_amount": "0",
+    "principal_amount": "0.00",
+    "special_principal_amount": "0.00",
+    "total_principal_amount": "0.00",
     "loan_balance_amount": "150000.00"
   },
   {
     "date": "2023-12-31T00:00:00",
     "payment_amount": "1687.50",
     "interest_amount": "1687.50",
-    "principal_amount": "0",
-    "special_principal_amount": "0",
-    "total_principal_amount": "0",
+    "principal_amount": "0.00",
+    "special_principal_amount": "0.00",
+    "total_principal_amount": "0.00",
     "loan_balance_amount": "150000.00"
   },
   {
     "date": "2024-03-31T00:00:00",
     "payment_amount": "1687.50",
     "interest_amount": "1687.50",
-    "principal_amount": "0",
-    "special_principal_amount": "0",
-    "total_principal_amount": "0",
+    "principal_amount": "0.00",
+    "special_principal_amount": "0.00",
+    "total_principal_amount": "0.00",
     "loan_balance_amount": "150000.00"
   },
   {
@@ -49,7 +49,7 @@
     "payment_amount": "4366.07",
     "interest_amount": "1687.50",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "147321.43"
   },
@@ -58,7 +58,7 @@
     "payment_amount": "4335.94",
     "interest_amount": "1657.37",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "144642.86"
   },
@@ -67,7 +67,7 @@
     "payment_amount": "4305.80",
     "interest_amount": "1627.23",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "141964.29"
   },
@@ -76,7 +76,7 @@
     "payment_amount": "4275.67",
     "interest_amount": "1597.10",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "139285.72"
   },
@@ -85,7 +85,7 @@
     "payment_amount": "4245.53",
     "interest_amount": "1566.96",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "136607.15"
   },
@@ -94,7 +94,7 @@
     "payment_amount": "4215.40",
     "interest_amount": "1536.83",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "133928.58"
   },
@@ -103,7 +103,7 @@
     "payment_amount": "4185.27",
     "interest_amount": "1506.70",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "131250.01"
   },
@@ -112,7 +112,7 @@
     "payment_amount": "4155.13",
     "interest_amount": "1476.56",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "128571.44"
   },
@@ -121,7 +121,7 @@
     "payment_amount": "4125.00",
     "interest_amount": "1446.43",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "125892.87"
   },
@@ -130,7 +130,7 @@
     "payment_amount": "4094.86",
     "interest_amount": "1416.29",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "123214.30"
   },
@@ -139,7 +139,7 @@
     "payment_amount": "4064.73",
     "interest_amount": "1386.16",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "120535.73"
   },
@@ -148,7 +148,7 @@
     "payment_amount": "4034.60",
     "interest_amount": "1356.03",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "117857.16"
   },
@@ -157,7 +157,7 @@
     "payment_amount": "4004.46",
     "interest_amount": "1325.89",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "115178.59"
   },
@@ -166,7 +166,7 @@
     "payment_amount": "3974.33",
     "interest_amount": "1295.76",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "112500.02"
   },
@@ -175,7 +175,7 @@
     "payment_amount": "3944.20",
     "interest_amount": "1265.63",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "109821.45"
   },
@@ -184,7 +184,7 @@
     "payment_amount": "3914.06",
     "interest_amount": "1235.49",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "107142.88"
   },
@@ -193,7 +193,7 @@
     "payment_amount": "3883.93",
     "interest_amount": "1205.36",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "104464.31"
   },
@@ -202,7 +202,7 @@
     "payment_amount": "3853.79",
     "interest_amount": "1175.22",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "101785.74"
   },
@@ -211,7 +211,7 @@
     "payment_amount": "3823.66",
     "interest_amount": "1145.09",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "99107.17"
   },
@@ -220,7 +220,7 @@
     "payment_amount": "3793.53",
     "interest_amount": "1114.96",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "96428.60"
   },
@@ -229,7 +229,7 @@
     "payment_amount": "3763.39",
     "interest_amount": "1084.82",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "93750.03"
   },
@@ -238,7 +238,7 @@
     "payment_amount": "3733.26",
     "interest_amount": "1054.69",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "91071.46"
   },
@@ -247,7 +247,7 @@
     "payment_amount": "3703.12",
     "interest_amount": "1024.55",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "88392.89"
   },
@@ -256,7 +256,7 @@
     "payment_amount": "3672.99",
     "interest_amount": "994.42",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "85714.32"
   },
@@ -265,7 +265,7 @@
     "payment_amount": "3642.86",
     "interest_amount": "964.29",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "83035.75"
   },
@@ -274,7 +274,7 @@
     "payment_amount": "3612.72",
     "interest_amount": "934.15",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "80357.18"
   },
@@ -283,7 +283,7 @@
     "payment_amount": "3582.59",
     "interest_amount": "904.02",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "77678.61"
   },
@@ -292,7 +292,7 @@
     "payment_amount": "3552.45",
     "interest_amount": "873.88",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "75000.04"
   },
@@ -301,7 +301,7 @@
     "payment_amount": "3522.32",
     "interest_amount": "843.75",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "72321.47"
   },
@@ -310,7 +310,7 @@
     "payment_amount": "3492.19",
     "interest_amount": "813.62",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "69642.90"
   },
@@ -319,7 +319,7 @@
     "payment_amount": "3462.05",
     "interest_amount": "783.48",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "66964.33"
   },
@@ -328,7 +328,7 @@
     "payment_amount": "3431.92",
     "interest_amount": "753.35",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "64285.76"
   },
@@ -337,7 +337,7 @@
     "payment_amount": "3401.78",
     "interest_amount": "723.21",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "61607.19"
   },
@@ -346,7 +346,7 @@
     "payment_amount": "3371.65",
     "interest_amount": "693.08",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "58928.62"
   },
@@ -355,7 +355,7 @@
     "payment_amount": "3341.52",
     "interest_amount": "662.95",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "56250.05"
   },
@@ -364,7 +364,7 @@
     "payment_amount": "3311.38",
     "interest_amount": "632.81",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "53571.48"
   },
@@ -373,7 +373,7 @@
     "payment_amount": "3281.25",
     "interest_amount": "602.68",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "50892.91"
   },
@@ -382,7 +382,7 @@
     "payment_amount": "3251.12",
     "interest_amount": "572.55",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "48214.34"
   },
@@ -391,7 +391,7 @@
     "payment_amount": "3220.98",
     "interest_amount": "542.41",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "45535.77"
   },
@@ -400,7 +400,7 @@
     "payment_amount": "3190.85",
     "interest_amount": "512.28",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "42857.20"
   },
@@ -409,7 +409,7 @@
     "payment_amount": "3160.71",
     "interest_amount": "482.14",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "40178.63"
   },
@@ -418,7 +418,7 @@
     "payment_amount": "3130.58",
     "interest_amount": "452.01",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "37500.06"
   },
@@ -427,7 +427,7 @@
     "payment_amount": "3100.45",
     "interest_amount": "421.88",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "34821.49"
   },
@@ -436,7 +436,7 @@
     "payment_amount": "3070.31",
     "interest_amount": "391.74",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "32142.92"
   },
@@ -445,7 +445,7 @@
     "payment_amount": "3040.18",
     "interest_amount": "361.61",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "29464.35"
   },
@@ -454,7 +454,7 @@
     "payment_amount": "3010.04",
     "interest_amount": "331.47",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "26785.78"
   },
@@ -463,7 +463,7 @@
     "payment_amount": "2979.91",
     "interest_amount": "301.34",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "24107.21"
   },
@@ -472,7 +472,7 @@
     "payment_amount": "2949.78",
     "interest_amount": "271.21",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "21428.64"
   },
@@ -481,7 +481,7 @@
     "payment_amount": "2919.64",
     "interest_amount": "241.07",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "18750.07"
   },
@@ -490,7 +490,7 @@
     "payment_amount": "2889.51",
     "interest_amount": "210.94",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "16071.50"
   },
@@ -499,7 +499,7 @@
     "payment_amount": "2859.37",
     "interest_amount": "180.80",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "13392.93"
   },
@@ -508,7 +508,7 @@
     "payment_amount": "2829.24",
     "interest_amount": "150.67",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "10714.36"
   },
@@ -517,7 +517,7 @@
     "payment_amount": "2799.11",
     "interest_amount": "120.54",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "8035.79"
   },
@@ -526,7 +526,7 @@
     "payment_amount": "2768.97",
     "interest_amount": "90.40",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "5357.22"
   },
@@ -535,7 +535,7 @@
     "payment_amount": "2738.84",
     "interest_amount": "60.27",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "2678.65"
   },
@@ -544,7 +544,7 @@
     "payment_amount": "2708.70",
     "interest_amount": "30.13",
     "principal_amount": "2678.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "2678.57",
     "loan_balance_amount": "0.08"
   }

--- a/tests/snapshots/standard_annuity_loan.json
+++ b/tests/snapshots/standard_annuity_loan.json
@@ -13,7 +13,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "966.67",
     "principal_amount": "232.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "232.43",
     "loan_balance_amount": "199767.57"
   },
@@ -22,7 +22,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "932.25",
     "principal_amount": "266.85",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "266.85",
     "loan_balance_amount": "199500.72"
   },
@@ -31,7 +31,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1064.00",
     "principal_amount": "135.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "135.10",
     "loan_balance_amount": "199365.62"
   },
@@ -40,7 +40,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "996.83",
     "principal_amount": "202.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "202.27",
     "loan_balance_amount": "199163.35"
   },
@@ -49,7 +49,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "995.82",
     "principal_amount": "203.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "203.28",
     "loan_balance_amount": "198960.07"
   },
@@ -58,7 +58,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "994.80",
     "principal_amount": "204.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "204.30",
     "loan_balance_amount": "198755.77"
   },
@@ -67,7 +67,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "993.78",
     "principal_amount": "205.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "205.32",
     "loan_balance_amount": "198550.45"
   },
@@ -76,7 +76,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "992.75",
     "principal_amount": "206.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "206.35",
     "loan_balance_amount": "198344.10"
   },
@@ -85,7 +85,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "991.72",
     "principal_amount": "207.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "207.38",
     "loan_balance_amount": "198136.72"
   },
@@ -94,7 +94,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "990.68",
     "principal_amount": "208.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "208.42",
     "loan_balance_amount": "197928.30"
   },
@@ -103,7 +103,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "989.64",
     "principal_amount": "209.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "209.46",
     "loan_balance_amount": "197718.84"
   },
@@ -112,7 +112,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "988.59",
     "principal_amount": "210.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "210.51",
     "loan_balance_amount": "197508.33"
   },
@@ -121,7 +121,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "987.54",
     "principal_amount": "211.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "211.56",
     "loan_balance_amount": "197296.77"
   },
@@ -130,7 +130,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "920.72",
     "principal_amount": "278.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "278.38",
     "loan_balance_amount": "197018.39"
   },
@@ -139,7 +139,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1050.76",
     "principal_amount": "148.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "148.34",
     "loan_balance_amount": "196870.05"
   },
@@ -148,7 +148,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "984.35",
     "principal_amount": "214.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "214.75",
     "loan_balance_amount": "196655.30"
   },
@@ -157,7 +157,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "983.28",
     "principal_amount": "215.82",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "215.82",
     "loan_balance_amount": "196439.48"
   },
@@ -166,7 +166,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "982.20",
     "principal_amount": "216.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "216.90",
     "loan_balance_amount": "196222.58"
   },
@@ -175,7 +175,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "981.11",
     "principal_amount": "217.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "217.99",
     "loan_balance_amount": "196004.59"
   },
@@ -184,7 +184,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "980.02",
     "principal_amount": "219.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "219.08",
     "loan_balance_amount": "195785.51"
   },
@@ -193,7 +193,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "978.93",
     "principal_amount": "220.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "220.17",
     "loan_balance_amount": "195565.34"
   },
@@ -202,7 +202,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "977.83",
     "principal_amount": "221.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "221.27",
     "loan_balance_amount": "195344.07"
   },
@@ -211,7 +211,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "976.72",
     "principal_amount": "222.38",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "222.38",
     "loan_balance_amount": "195121.69"
   },
@@ -220,7 +220,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "975.61",
     "principal_amount": "223.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "223.49",
     "loan_balance_amount": "194898.20"
   },
@@ -229,7 +229,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "974.49",
     "principal_amount": "224.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "224.61",
     "loan_balance_amount": "194673.59"
   },
@@ -238,7 +238,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "940.92",
     "principal_amount": "258.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "258.18",
     "loan_balance_amount": "194415.41"
   },
@@ -247,7 +247,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1004.48",
     "principal_amount": "194.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "194.62",
     "loan_balance_amount": "194220.79"
   },
@@ -256,7 +256,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "971.10",
     "principal_amount": "228.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "228.00",
     "loan_balance_amount": "193992.79"
   },
@@ -265,7 +265,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "969.96",
     "principal_amount": "229.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "229.14",
     "loan_balance_amount": "193763.65"
   },
@@ -274,7 +274,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "968.82",
     "principal_amount": "230.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "230.28",
     "loan_balance_amount": "193533.37"
   },
@@ -283,7 +283,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "967.67",
     "principal_amount": "231.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "231.43",
     "loan_balance_amount": "193301.94"
   },
@@ -292,7 +292,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "966.51",
     "principal_amount": "232.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "232.59",
     "loan_balance_amount": "193069.35"
   },
@@ -301,7 +301,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "965.35",
     "principal_amount": "233.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "233.75",
     "loan_balance_amount": "192835.60"
   },
@@ -310,7 +310,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "964.18",
     "principal_amount": "234.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "234.92",
     "loan_balance_amount": "192600.68"
   },
@@ -319,7 +319,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "963.00",
     "principal_amount": "236.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "236.10",
     "loan_balance_amount": "192364.58"
   },
@@ -328,7 +328,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "961.82",
     "principal_amount": "237.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "237.28",
     "loan_balance_amount": "192127.30"
   },
@@ -337,7 +337,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "960.64",
     "principal_amount": "238.46",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "238.46",
     "loan_balance_amount": "191888.84"
   },
@@ -346,7 +346,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "895.48",
     "principal_amount": "303.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "303.62",
     "loan_balance_amount": "191585.22"
   },
@@ -355,7 +355,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1021.79",
     "principal_amount": "177.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "177.31",
     "loan_balance_amount": "191407.91"
   },
@@ -364,7 +364,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "957.04",
     "principal_amount": "242.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "242.06",
     "loan_balance_amount": "191165.85"
   },
@@ -373,7 +373,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "955.83",
     "principal_amount": "243.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "243.27",
     "loan_balance_amount": "190922.58"
   },
@@ -382,7 +382,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "954.61",
     "principal_amount": "244.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "244.49",
     "loan_balance_amount": "190678.09"
   },
@@ -391,7 +391,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "953.39",
     "principal_amount": "245.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "245.71",
     "loan_balance_amount": "190432.38"
   },
@@ -400,7 +400,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "952.16",
     "principal_amount": "246.94",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "246.94",
     "loan_balance_amount": "190185.44"
   },
@@ -409,7 +409,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "950.93",
     "principal_amount": "248.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "248.17",
     "loan_balance_amount": "189937.27"
   },
@@ -418,7 +418,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "949.69",
     "principal_amount": "249.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "249.41",
     "loan_balance_amount": "189687.86"
   },
@@ -427,7 +427,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "948.44",
     "principal_amount": "250.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "250.66",
     "loan_balance_amount": "189437.20"
   },
@@ -436,7 +436,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "947.19",
     "principal_amount": "251.91",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "251.91",
     "loan_balance_amount": "189185.29"
   },
@@ -445,7 +445,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "945.93",
     "principal_amount": "253.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "253.17",
     "loan_balance_amount": "188932.12"
   },
@@ -454,7 +454,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "881.68",
     "principal_amount": "317.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "317.42",
     "loan_balance_amount": "188614.70"
   },
@@ -463,7 +463,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "1005.95",
     "principal_amount": "193.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "193.15",
     "loan_balance_amount": "188421.55"
   },
@@ -472,7 +472,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "942.11",
     "principal_amount": "256.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "256.99",
     "loan_balance_amount": "188164.56"
   },
@@ -481,7 +481,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "940.82",
     "principal_amount": "258.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "258.28",
     "loan_balance_amount": "187906.28"
   },
@@ -490,7 +490,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "939.53",
     "principal_amount": "259.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "259.57",
     "loan_balance_amount": "187646.71"
   },
@@ -499,7 +499,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "938.23",
     "principal_amount": "260.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "260.87",
     "loan_balance_amount": "187385.84"
   },
@@ -508,7 +508,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "936.93",
     "principal_amount": "262.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "262.17",
     "loan_balance_amount": "187123.67"
   },
@@ -517,7 +517,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "935.62",
     "principal_amount": "263.48",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "263.48",
     "loan_balance_amount": "186860.19"
   },
@@ -526,7 +526,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "934.30",
     "principal_amount": "264.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "264.80",
     "loan_balance_amount": "186595.39"
   },
@@ -535,7 +535,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "932.98",
     "principal_amount": "266.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "266.12",
     "loan_balance_amount": "186329.27"
   },
@@ -544,7 +544,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "931.65",
     "principal_amount": "267.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "267.45",
     "loan_balance_amount": "186061.82"
   },
@@ -553,7 +553,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "930.31",
     "principal_amount": "268.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "268.79",
     "loan_balance_amount": "185793.03"
   },
@@ -562,7 +562,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "867.03",
     "principal_amount": "332.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "332.07",
     "loan_balance_amount": "185460.96"
   },
@@ -571,7 +571,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "989.13",
     "principal_amount": "209.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "209.97",
     "loan_balance_amount": "185250.99"
   },
@@ -580,7 +580,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "926.25",
     "principal_amount": "272.85",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "272.85",
     "loan_balance_amount": "184978.14"
   },
@@ -589,7 +589,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "924.89",
     "principal_amount": "274.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "274.21",
     "loan_balance_amount": "184703.93"
   },
@@ -598,7 +598,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "923.52",
     "principal_amount": "275.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "275.58",
     "loan_balance_amount": "184428.35"
   },
@@ -607,7 +607,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "922.14",
     "principal_amount": "276.96",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "276.96",
     "loan_balance_amount": "184151.39"
   },
@@ -616,7 +616,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "920.76",
     "principal_amount": "278.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "278.34",
     "loan_balance_amount": "183873.05"
   },
@@ -625,7 +625,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "919.37",
     "principal_amount": "279.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "279.73",
     "loan_balance_amount": "183593.32"
   },
@@ -634,7 +634,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "917.97",
     "principal_amount": "281.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "281.13",
     "loan_balance_amount": "183312.19"
   },
@@ -643,7 +643,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "916.56",
     "principal_amount": "282.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "282.54",
     "loan_balance_amount": "183029.65"
   },
@@ -652,7 +652,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "915.15",
     "principal_amount": "283.95",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "283.95",
     "loan_balance_amount": "182745.70"
   },
@@ -661,7 +661,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "913.73",
     "principal_amount": "285.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "285.37",
     "loan_balance_amount": "182460.33"
   },
@@ -670,7 +670,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "881.89",
     "principal_amount": "317.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "317.21",
     "loan_balance_amount": "182143.12"
   },
@@ -679,7 +679,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "941.07",
     "principal_amount": "258.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "258.03",
     "loan_balance_amount": "181885.09"
   },
@@ -688,7 +688,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "909.43",
     "principal_amount": "289.67",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "289.67",
     "loan_balance_amount": "181595.42"
   },
@@ -697,7 +697,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "907.98",
     "principal_amount": "291.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "291.12",
     "loan_balance_amount": "181304.30"
   },
@@ -706,7 +706,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "906.52",
     "principal_amount": "292.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "292.58",
     "loan_balance_amount": "181011.72"
   },
@@ -715,7 +715,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "905.06",
     "principal_amount": "294.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "294.04",
     "loan_balance_amount": "180717.68"
   },
@@ -724,7 +724,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "903.59",
     "principal_amount": "295.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "295.51",
     "loan_balance_amount": "180422.17"
   },
@@ -733,7 +733,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "902.11",
     "principal_amount": "296.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "296.99",
     "loan_balance_amount": "180125.18"
   },
@@ -742,7 +742,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "900.63",
     "principal_amount": "298.47",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "298.47",
     "loan_balance_amount": "179826.71"
   },
@@ -751,7 +751,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "899.13",
     "principal_amount": "299.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "299.97",
     "loan_balance_amount": "179526.74"
   },
@@ -760,7 +760,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "897.63",
     "principal_amount": "301.47",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "301.47",
     "loan_balance_amount": "179225.27"
   },
@@ -769,7 +769,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "896.13",
     "principal_amount": "302.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "302.97",
     "loan_balance_amount": "178922.30"
   },
@@ -778,7 +778,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "834.97",
     "principal_amount": "364.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "364.13",
     "loan_balance_amount": "178558.17"
   },
@@ -787,7 +787,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "952.31",
     "principal_amount": "246.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "246.79",
     "loan_balance_amount": "178311.38"
   },
@@ -796,7 +796,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "891.56",
     "principal_amount": "307.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "307.54",
     "loan_balance_amount": "178003.84"
   },
@@ -805,7 +805,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "890.02",
     "principal_amount": "309.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "309.08",
     "loan_balance_amount": "177694.76"
   },
@@ -814,7 +814,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "888.47",
     "principal_amount": "310.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "310.63",
     "loan_balance_amount": "177384.13"
   },
@@ -823,7 +823,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "886.92",
     "principal_amount": "312.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "312.18",
     "loan_balance_amount": "177071.95"
   },
@@ -832,7 +832,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "885.36",
     "principal_amount": "313.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "313.74",
     "loan_balance_amount": "176758.21"
   },
@@ -841,7 +841,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "883.79",
     "principal_amount": "315.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "315.31",
     "loan_balance_amount": "176442.90"
   },
@@ -850,7 +850,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "882.21",
     "principal_amount": "316.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "316.89",
     "loan_balance_amount": "176126.01"
   },
@@ -859,7 +859,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "880.63",
     "principal_amount": "318.47",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "318.47",
     "loan_balance_amount": "175807.54"
   },
@@ -868,7 +868,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "879.04",
     "principal_amount": "320.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "320.06",
     "loan_balance_amount": "175487.48"
   },
@@ -877,7 +877,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "877.44",
     "principal_amount": "321.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "321.66",
     "loan_balance_amount": "175165.82"
   },
@@ -886,7 +886,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "817.44",
     "principal_amount": "381.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "381.66",
     "loan_balance_amount": "174784.16"
   },
@@ -895,7 +895,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "932.18",
     "principal_amount": "266.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "266.92",
     "loan_balance_amount": "174517.24"
   },
@@ -904,7 +904,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "872.59",
     "principal_amount": "326.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "326.51",
     "loan_balance_amount": "174190.73"
   },
@@ -913,7 +913,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "870.95",
     "principal_amount": "328.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "328.15",
     "loan_balance_amount": "173862.58"
   },
@@ -922,7 +922,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "869.31",
     "principal_amount": "329.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "329.79",
     "loan_balance_amount": "173532.79"
   },
@@ -931,7 +931,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "867.66",
     "principal_amount": "331.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "331.44",
     "loan_balance_amount": "173201.35"
   },
@@ -940,7 +940,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "866.01",
     "principal_amount": "333.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "333.09",
     "loan_balance_amount": "172868.26"
   },
@@ -949,7 +949,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "864.34",
     "principal_amount": "334.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "334.76",
     "loan_balance_amount": "172533.50"
   },
@@ -958,7 +958,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "862.67",
     "principal_amount": "336.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "336.43",
     "loan_balance_amount": "172197.07"
   },
@@ -967,7 +967,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "860.99",
     "principal_amount": "338.11",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "338.11",
     "loan_balance_amount": "171858.96"
   },
@@ -976,7 +976,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "859.29",
     "principal_amount": "339.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "339.81",
     "loan_balance_amount": "171519.15"
   },
@@ -985,7 +985,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "857.60",
     "principal_amount": "341.50",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "341.50",
     "loan_balance_amount": "171177.65"
   },
@@ -994,7 +994,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "798.83",
     "principal_amount": "400.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "400.27",
     "loan_balance_amount": "170777.38"
   },
@@ -1003,7 +1003,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "910.81",
     "principal_amount": "288.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "288.29",
     "loan_balance_amount": "170489.09"
   },
@@ -1012,7 +1012,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "852.45",
     "principal_amount": "346.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "346.65",
     "loan_balance_amount": "170142.44"
   },
@@ -1021,7 +1021,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "850.71",
     "principal_amount": "348.39",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "348.39",
     "loan_balance_amount": "169794.05"
   },
@@ -1030,7 +1030,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "848.97",
     "principal_amount": "350.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "350.13",
     "loan_balance_amount": "169443.92"
   },
@@ -1039,7 +1039,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "847.22",
     "principal_amount": "351.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "351.88",
     "loan_balance_amount": "169092.04"
   },
@@ -1048,7 +1048,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "845.46",
     "principal_amount": "353.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "353.64",
     "loan_balance_amount": "168738.40"
   },
@@ -1057,7 +1057,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "843.69",
     "principal_amount": "355.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "355.41",
     "loan_balance_amount": "168382.99"
   },
@@ -1066,7 +1066,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "841.91",
     "principal_amount": "357.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "357.19",
     "loan_balance_amount": "168025.80"
   },
@@ -1075,7 +1075,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "840.13",
     "principal_amount": "358.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "358.97",
     "loan_balance_amount": "167666.83"
   },
@@ -1084,7 +1084,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "838.33",
     "principal_amount": "360.77",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "360.77",
     "loan_balance_amount": "167306.06"
   },
@@ -1093,7 +1093,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "836.53",
     "principal_amount": "362.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "362.57",
     "loan_balance_amount": "166943.49"
   },
@@ -1102,7 +1102,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "806.89",
     "principal_amount": "392.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "392.21",
     "loan_balance_amount": "166551.28"
   },
@@ -1111,7 +1111,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "860.51",
     "principal_amount": "338.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "338.59",
     "loan_balance_amount": "166212.69"
   },
@@ -1120,7 +1120,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "831.06",
     "principal_amount": "368.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "368.04",
     "loan_balance_amount": "165844.65"
   },
@@ -1129,7 +1129,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "829.22",
     "principal_amount": "369.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "369.88",
     "loan_balance_amount": "165474.77"
   },
@@ -1138,7 +1138,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "827.37",
     "principal_amount": "371.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "371.73",
     "loan_balance_amount": "165103.04"
   },
@@ -1147,7 +1147,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "825.52",
     "principal_amount": "373.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "373.58",
     "loan_balance_amount": "164729.46"
   },
@@ -1156,7 +1156,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "823.65",
     "principal_amount": "375.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "375.45",
     "loan_balance_amount": "164354.01"
   },
@@ -1165,7 +1165,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "821.77",
     "principal_amount": "377.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "377.33",
     "loan_balance_amount": "163976.68"
   },
@@ -1174,7 +1174,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "819.88",
     "principal_amount": "379.22",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "379.22",
     "loan_balance_amount": "163597.46"
   },
@@ -1183,7 +1183,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "817.99",
     "principal_amount": "381.11",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "381.11",
     "loan_balance_amount": "163216.35"
   },
@@ -1192,7 +1192,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "816.08",
     "principal_amount": "383.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "383.02",
     "loan_balance_amount": "162833.33"
   },
@@ -1201,7 +1201,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "814.17",
     "principal_amount": "384.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "384.93",
     "loan_balance_amount": "162448.40"
   },
@@ -1210,7 +1210,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "758.09",
     "principal_amount": "441.01",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "441.01",
     "loan_balance_amount": "162007.39"
   },
@@ -1219,7 +1219,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "864.04",
     "principal_amount": "335.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "335.06",
     "loan_balance_amount": "161672.33"
   },
@@ -1228,7 +1228,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "808.36",
     "principal_amount": "390.74",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "390.74",
     "loan_balance_amount": "161281.59"
   },
@@ -1237,7 +1237,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "806.41",
     "principal_amount": "392.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "392.69",
     "loan_balance_amount": "160888.90"
   },
@@ -1246,7 +1246,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "804.44",
     "principal_amount": "394.66",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "394.66",
     "loan_balance_amount": "160494.24"
   },
@@ -1255,7 +1255,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "802.47",
     "principal_amount": "396.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "396.63",
     "loan_balance_amount": "160097.61"
   },
@@ -1264,7 +1264,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "800.49",
     "principal_amount": "398.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "398.61",
     "loan_balance_amount": "159699.00"
   },
@@ -1273,7 +1273,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "798.49",
     "principal_amount": "400.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "400.61",
     "loan_balance_amount": "159298.39"
   },
@@ -1282,7 +1282,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "796.49",
     "principal_amount": "402.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "402.61",
     "loan_balance_amount": "158895.78"
   },
@@ -1291,7 +1291,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "794.48",
     "principal_amount": "404.62",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "404.62",
     "loan_balance_amount": "158491.16"
   },
@@ -1300,7 +1300,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "792.46",
     "principal_amount": "406.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "406.64",
     "loan_balance_amount": "158084.52"
   },
@@ -1309,7 +1309,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "790.42",
     "principal_amount": "408.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "408.68",
     "loan_balance_amount": "157675.84"
   },
@@ -1318,7 +1318,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "735.82",
     "principal_amount": "463.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "463.28",
     "loan_balance_amount": "157212.56"
   },
@@ -1327,7 +1327,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "838.47",
     "principal_amount": "360.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "360.63",
     "loan_balance_amount": "156851.93"
   },
@@ -1336,7 +1336,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "784.26",
     "principal_amount": "414.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "414.84",
     "loan_balance_amount": "156437.09"
   },
@@ -1345,7 +1345,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "782.19",
     "principal_amount": "416.91",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "416.91",
     "loan_balance_amount": "156020.18"
   },
@@ -1354,7 +1354,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "780.10",
     "principal_amount": "419.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "419.00",
     "loan_balance_amount": "155601.18"
   },
@@ -1363,7 +1363,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "778.01",
     "principal_amount": "421.09",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "421.09",
     "loan_balance_amount": "155180.09"
   },
@@ -1372,7 +1372,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "775.90",
     "principal_amount": "423.20",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "423.20",
     "loan_balance_amount": "154756.89"
   },
@@ -1381,7 +1381,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "773.78",
     "principal_amount": "425.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "425.32",
     "loan_balance_amount": "154331.57"
   },
@@ -1390,7 +1390,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "771.66",
     "principal_amount": "427.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "427.44",
     "loan_balance_amount": "153904.13"
   },
@@ -1399,7 +1399,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "769.52",
     "principal_amount": "429.58",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "429.58",
     "loan_balance_amount": "153474.55"
   },
@@ -1408,7 +1408,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "767.37",
     "principal_amount": "431.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "431.73",
     "loan_balance_amount": "153042.82"
   },
@@ -1417,7 +1417,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "765.21",
     "principal_amount": "433.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "433.89",
     "loan_balance_amount": "152608.93"
   },
@@ -1426,7 +1426,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "712.18",
     "principal_amount": "486.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "486.92",
     "loan_balance_amount": "152122.01"
   },
@@ -1435,7 +1435,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "811.32",
     "principal_amount": "387.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "387.78",
     "loan_balance_amount": "151734.23"
   },
@@ -1444,7 +1444,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "758.67",
     "principal_amount": "440.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "440.43",
     "loan_balance_amount": "151293.80"
   },
@@ -1453,7 +1453,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "756.47",
     "principal_amount": "442.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "442.63",
     "loan_balance_amount": "150851.17"
   },
@@ -1462,7 +1462,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "754.26",
     "principal_amount": "444.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "444.84",
     "loan_balance_amount": "150406.33"
   },
@@ -1471,7 +1471,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "752.03",
     "principal_amount": "447.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "447.07",
     "loan_balance_amount": "149959.26"
   },
@@ -1480,7 +1480,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "749.80",
     "principal_amount": "449.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "449.30",
     "loan_balance_amount": "149509.96"
   },
@@ -1489,7 +1489,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "747.55",
     "principal_amount": "451.55",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "451.55",
     "loan_balance_amount": "149058.41"
   },
@@ -1498,7 +1498,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "745.29",
     "principal_amount": "453.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "453.81",
     "loan_balance_amount": "148604.60"
   },
@@ -1507,7 +1507,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "743.02",
     "principal_amount": "456.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "456.08",
     "loan_balance_amount": "148148.52"
   },
@@ -1516,7 +1516,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "740.74",
     "principal_amount": "458.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "458.36",
     "loan_balance_amount": "147690.16"
   },
@@ -1525,7 +1525,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "738.45",
     "principal_amount": "460.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "460.65",
     "loan_balance_amount": "147229.51"
   },
@@ -1534,7 +1534,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "711.61",
     "principal_amount": "487.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "487.49",
     "loan_balance_amount": "146742.02"
   },
@@ -1543,7 +1543,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "758.17",
     "principal_amount": "440.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "440.93",
     "loan_balance_amount": "146301.09"
   },
@@ -1552,7 +1552,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "731.51",
     "principal_amount": "467.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "467.59",
     "loan_balance_amount": "145833.50"
   },
@@ -1561,7 +1561,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "729.17",
     "principal_amount": "469.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "469.93",
     "loan_balance_amount": "145363.57"
   },
@@ -1570,7 +1570,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "726.82",
     "principal_amount": "472.28",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "472.28",
     "loan_balance_amount": "144891.29"
   },
@@ -1579,7 +1579,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "724.46",
     "principal_amount": "474.64",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "474.64",
     "loan_balance_amount": "144416.65"
   },
@@ -1588,7 +1588,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "722.08",
     "principal_amount": "477.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "477.02",
     "loan_balance_amount": "143939.63"
   },
@@ -1597,7 +1597,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "719.70",
     "principal_amount": "479.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "479.40",
     "loan_balance_amount": "143460.23"
   },
@@ -1606,7 +1606,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "717.30",
     "principal_amount": "481.80",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "481.80",
     "loan_balance_amount": "142978.43"
   },
@@ -1615,7 +1615,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "714.89",
     "principal_amount": "484.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "484.21",
     "loan_balance_amount": "142494.22"
   },
@@ -1624,7 +1624,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "712.47",
     "principal_amount": "486.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "486.63",
     "loan_balance_amount": "142007.59"
   },
@@ -1633,7 +1633,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "710.04",
     "principal_amount": "489.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "489.06",
     "loan_balance_amount": "141518.53"
   },
@@ -1642,7 +1642,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "660.42",
     "principal_amount": "538.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "538.68",
     "loan_balance_amount": "140979.85"
   },
@@ -1651,7 +1651,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "751.89",
     "principal_amount": "447.21",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "447.21",
     "loan_balance_amount": "140532.64"
   },
@@ -1660,7 +1660,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "702.66",
     "principal_amount": "496.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "496.44",
     "loan_balance_amount": "140036.20"
   },
@@ -1669,7 +1669,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "700.18",
     "principal_amount": "498.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "498.92",
     "loan_balance_amount": "139537.28"
   },
@@ -1678,7 +1678,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "697.69",
     "principal_amount": "501.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "501.41",
     "loan_balance_amount": "139035.87"
   },
@@ -1687,7 +1687,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "695.18",
     "principal_amount": "503.92",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "503.92",
     "loan_balance_amount": "138531.95"
   },
@@ -1696,7 +1696,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "692.66",
     "principal_amount": "506.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "506.44",
     "loan_balance_amount": "138025.51"
   },
@@ -1705,7 +1705,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "690.13",
     "principal_amount": "508.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "508.97",
     "loan_balance_amount": "137516.54"
   },
@@ -1714,7 +1714,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "687.58",
     "principal_amount": "511.52",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "511.52",
     "loan_balance_amount": "137005.02"
   },
@@ -1723,7 +1723,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "685.03",
     "principal_amount": "514.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "514.07",
     "loan_balance_amount": "136490.95"
   },
@@ -1732,7 +1732,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "682.45",
     "principal_amount": "516.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "516.65",
     "loan_balance_amount": "135974.30"
   },
@@ -1741,7 +1741,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "679.87",
     "principal_amount": "519.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "519.23",
     "loan_balance_amount": "135455.07"
   },
@@ -1750,7 +1750,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "632.12",
     "principal_amount": "566.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "566.98",
     "loan_balance_amount": "134888.09"
   },
@@ -1759,7 +1759,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "719.40",
     "principal_amount": "479.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "479.70",
     "loan_balance_amount": "134408.39"
   },
@@ -1768,7 +1768,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "672.04",
     "principal_amount": "527.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "527.06",
     "loan_balance_amount": "133881.33"
   },
@@ -1777,7 +1777,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "669.41",
     "principal_amount": "529.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "529.69",
     "loan_balance_amount": "133351.64"
   },
@@ -1786,7 +1786,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "666.76",
     "principal_amount": "532.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "532.34",
     "loan_balance_amount": "132819.30"
   },
@@ -1795,7 +1795,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "664.10",
     "principal_amount": "535.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "535.00",
     "loan_balance_amount": "132284.30"
   },
@@ -1804,7 +1804,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "661.42",
     "principal_amount": "537.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "537.68",
     "loan_balance_amount": "131746.62"
   },
@@ -1813,7 +1813,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "658.73",
     "principal_amount": "540.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "540.37",
     "loan_balance_amount": "131206.25"
   },
@@ -1822,7 +1822,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "656.03",
     "principal_amount": "543.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "543.07",
     "loan_balance_amount": "130663.18"
   },
@@ -1831,7 +1831,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "653.32",
     "principal_amount": "545.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "545.78",
     "loan_balance_amount": "130117.40"
   },
@@ -1840,7 +1840,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "650.59",
     "principal_amount": "548.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "548.51",
     "loan_balance_amount": "129568.89"
   },
@@ -1849,7 +1849,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "647.84",
     "principal_amount": "551.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "551.26",
     "loan_balance_amount": "129017.63"
   },
@@ -1858,7 +1858,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "602.08",
     "principal_amount": "597.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "597.02",
     "loan_balance_amount": "128420.61"
   },
@@ -1867,7 +1867,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "684.91",
     "principal_amount": "514.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "514.19",
     "loan_balance_amount": "127906.42"
   },
@@ -1876,7 +1876,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "639.53",
     "principal_amount": "559.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "559.57",
     "loan_balance_amount": "127346.85"
   },
@@ -1885,7 +1885,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "636.73",
     "principal_amount": "562.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "562.37",
     "loan_balance_amount": "126784.48"
   },
@@ -1894,7 +1894,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "633.92",
     "principal_amount": "565.18",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "565.18",
     "loan_balance_amount": "126219.30"
   },
@@ -1903,7 +1903,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "631.10",
     "principal_amount": "568.00",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "568.00",
     "loan_balance_amount": "125651.30"
   },
@@ -1912,7 +1912,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "628.26",
     "principal_amount": "570.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "570.84",
     "loan_balance_amount": "125080.46"
   },
@@ -1921,7 +1921,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "625.40",
     "principal_amount": "573.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "573.70",
     "loan_balance_amount": "124506.76"
   },
@@ -1930,7 +1930,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "622.53",
     "principal_amount": "576.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "576.57",
     "loan_balance_amount": "123930.19"
   },
@@ -1939,7 +1939,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "619.65",
     "principal_amount": "579.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "579.45",
     "loan_balance_amount": "123350.74"
   },
@@ -1948,7 +1948,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "616.75",
     "principal_amount": "582.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "582.35",
     "loan_balance_amount": "122768.39"
   },
@@ -1957,7 +1957,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "613.84",
     "principal_amount": "585.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "585.26",
     "loan_balance_amount": "122183.13"
   },
@@ -1966,7 +1966,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "590.55",
     "principal_amount": "608.55",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "608.55",
     "loan_balance_amount": "121574.58"
   },
@@ -1975,7 +1975,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "628.14",
     "principal_amount": "570.96",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "570.96",
     "loan_balance_amount": "121003.62"
   },
@@ -1984,7 +1984,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "605.02",
     "principal_amount": "594.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "594.08",
     "loan_balance_amount": "120409.54"
   },
@@ -1993,7 +1993,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "602.05",
     "principal_amount": "597.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "597.05",
     "loan_balance_amount": "119812.49"
   },
@@ -2002,7 +2002,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "599.06",
     "principal_amount": "600.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "600.04",
     "loan_balance_amount": "119212.45"
   },
@@ -2011,7 +2011,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "596.06",
     "principal_amount": "603.04",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "603.04",
     "loan_balance_amount": "118609.41"
   },
@@ -2020,7 +2020,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "593.05",
     "principal_amount": "606.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "606.05",
     "loan_balance_amount": "118003.36"
   },
@@ -2029,7 +2029,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "590.02",
     "principal_amount": "609.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "609.08",
     "loan_balance_amount": "117394.28"
   },
@@ -2038,7 +2038,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "586.97",
     "principal_amount": "612.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "612.13",
     "loan_balance_amount": "116782.15"
   },
@@ -2047,7 +2047,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "583.91",
     "principal_amount": "615.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "615.19",
     "loan_balance_amount": "116166.96"
   },
@@ -2056,7 +2056,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "580.83",
     "principal_amount": "618.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "618.27",
     "loan_balance_amount": "115548.69"
   },
@@ -2065,7 +2065,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "577.74",
     "principal_amount": "621.36",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "621.36",
     "loan_balance_amount": "114927.33"
   },
@@ -2074,7 +2074,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "536.33",
     "principal_amount": "662.77",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "662.77",
     "loan_balance_amount": "114264.56"
   },
@@ -2083,7 +2083,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "609.41",
     "principal_amount": "589.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "589.69",
     "loan_balance_amount": "113674.87"
   },
@@ -2092,7 +2092,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "568.37",
     "principal_amount": "630.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "630.73",
     "loan_balance_amount": "113044.14"
   },
@@ -2101,7 +2101,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "565.22",
     "principal_amount": "633.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "633.88",
     "loan_balance_amount": "112410.26"
   },
@@ -2110,7 +2110,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "562.05",
     "principal_amount": "637.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "637.05",
     "loan_balance_amount": "111773.21"
   },
@@ -2119,7 +2119,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "558.87",
     "principal_amount": "640.23",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "640.23",
     "loan_balance_amount": "111132.98"
   },
@@ -2128,7 +2128,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "555.66",
     "principal_amount": "643.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "643.44",
     "loan_balance_amount": "110489.54"
   },
@@ -2137,7 +2137,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "552.45",
     "principal_amount": "646.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "646.65",
     "loan_balance_amount": "109842.89"
   },
@@ -2146,7 +2146,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "549.21",
     "principal_amount": "649.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "649.89",
     "loan_balance_amount": "109193.00"
   },
@@ -2155,7 +2155,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "545.96",
     "principal_amount": "653.14",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "653.14",
     "loan_balance_amount": "108539.86"
   },
@@ -2164,7 +2164,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "542.70",
     "principal_amount": "656.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "656.40",
     "loan_balance_amount": "107883.46"
   },
@@ -2173,7 +2173,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "539.42",
     "principal_amount": "659.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "659.68",
     "loan_balance_amount": "107223.78"
   },
@@ -2182,7 +2182,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "500.38",
     "principal_amount": "698.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "698.72",
     "loan_balance_amount": "106525.06"
   },
@@ -2191,7 +2191,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "568.13",
     "principal_amount": "630.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "630.97",
     "loan_balance_amount": "105894.09"
   },
@@ -2200,7 +2200,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "529.47",
     "principal_amount": "669.63",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "669.63",
     "loan_balance_amount": "105224.46"
   },
@@ -2209,7 +2209,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "526.12",
     "principal_amount": "672.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "672.98",
     "loan_balance_amount": "104551.48"
   },
@@ -2218,7 +2218,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "522.76",
     "principal_amount": "676.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "676.34",
     "loan_balance_amount": "103875.14"
   },
@@ -2227,7 +2227,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "519.38",
     "principal_amount": "679.72",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "679.72",
     "loan_balance_amount": "103195.42"
   },
@@ -2236,7 +2236,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "515.98",
     "principal_amount": "683.12",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "683.12",
     "loan_balance_amount": "102512.30"
   },
@@ -2245,7 +2245,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "512.56",
     "principal_amount": "686.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "686.54",
     "loan_balance_amount": "101825.76"
   },
@@ -2254,7 +2254,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "509.13",
     "principal_amount": "689.97",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "689.97",
     "loan_balance_amount": "101135.79"
   },
@@ -2263,7 +2263,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "505.68",
     "principal_amount": "693.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "693.42",
     "loan_balance_amount": "100442.37"
   },
@@ -2272,7 +2272,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "502.21",
     "principal_amount": "696.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "696.89",
     "loan_balance_amount": "99745.48"
   },
@@ -2281,7 +2281,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "498.73",
     "principal_amount": "700.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "700.37",
     "loan_balance_amount": "99045.11"
   },
@@ -2290,7 +2290,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "462.21",
     "principal_amount": "736.89",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "736.89",
     "loan_balance_amount": "98308.22"
   },
@@ -2299,7 +2299,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "524.31",
     "principal_amount": "674.79",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "674.79",
     "loan_balance_amount": "97633.43"
   },
@@ -2308,7 +2308,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "488.17",
     "principal_amount": "710.93",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "710.93",
     "loan_balance_amount": "96922.50"
   },
@@ -2317,7 +2317,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "484.61",
     "principal_amount": "714.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "714.49",
     "loan_balance_amount": "96208.01"
   },
@@ -2326,7 +2326,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "481.04",
     "principal_amount": "718.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "718.06",
     "loan_balance_amount": "95489.95"
   },
@@ -2335,7 +2335,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "477.45",
     "principal_amount": "721.65",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "721.65",
     "loan_balance_amount": "94768.30"
   },
@@ -2344,7 +2344,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "473.84",
     "principal_amount": "725.26",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "725.26",
     "loan_balance_amount": "94043.04"
   },
@@ -2353,7 +2353,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "470.22",
     "principal_amount": "728.88",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "728.88",
     "loan_balance_amount": "93314.16"
   },
@@ -2362,7 +2362,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "466.57",
     "principal_amount": "732.53",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "732.53",
     "loan_balance_amount": "92581.63"
   },
@@ -2371,7 +2371,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "462.91",
     "principal_amount": "736.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "736.19",
     "loan_balance_amount": "91845.44"
   },
@@ -2380,7 +2380,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "459.23",
     "principal_amount": "739.87",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "739.87",
     "loan_balance_amount": "91105.57"
   },
@@ -2389,7 +2389,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "455.53",
     "principal_amount": "743.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "743.57",
     "loan_balance_amount": "90362.00"
   },
@@ -2398,7 +2398,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "436.75",
     "principal_amount": "762.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "762.35",
     "loan_balance_amount": "89599.65"
   },
@@ -2407,7 +2407,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "462.93",
     "principal_amount": "736.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "736.17",
     "loan_balance_amount": "88863.48"
   },
@@ -2416,7 +2416,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "444.32",
     "principal_amount": "754.78",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "754.78",
     "loan_balance_amount": "88108.70"
   },
@@ -2425,7 +2425,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "440.54",
     "principal_amount": "758.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "758.56",
     "loan_balance_amount": "87350.14"
   },
@@ -2434,7 +2434,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "436.75",
     "principal_amount": "762.35",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "762.35",
     "loan_balance_amount": "86587.79"
   },
@@ -2443,7 +2443,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "432.94",
     "principal_amount": "766.16",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "766.16",
     "loan_balance_amount": "85821.63"
   },
@@ -2452,7 +2452,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "429.11",
     "principal_amount": "769.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "769.99",
     "loan_balance_amount": "85051.64"
   },
@@ -2461,7 +2461,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "425.26",
     "principal_amount": "773.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "773.84",
     "loan_balance_amount": "84277.80"
   },
@@ -2470,7 +2470,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "421.39",
     "principal_amount": "777.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "777.71",
     "loan_balance_amount": "83500.09"
   },
@@ -2479,7 +2479,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "417.50",
     "principal_amount": "781.60",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "781.60",
     "loan_balance_amount": "82718.49"
   },
@@ -2488,7 +2488,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "413.59",
     "principal_amount": "785.51",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "785.51",
     "loan_balance_amount": "81932.98"
   },
@@ -2497,7 +2497,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "409.66",
     "principal_amount": "789.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "789.44",
     "loan_balance_amount": "81143.54"
   },
@@ -2506,7 +2506,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "378.67",
     "principal_amount": "820.43",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "820.43",
     "loan_balance_amount": "80323.11"
   },
@@ -2515,7 +2515,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "428.39",
     "principal_amount": "770.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "770.71",
     "loan_balance_amount": "79552.40"
   },
@@ -2524,7 +2524,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "397.76",
     "principal_amount": "801.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "801.34",
     "loan_balance_amount": "78751.06"
   },
@@ -2533,7 +2533,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "393.76",
     "principal_amount": "805.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "805.34",
     "loan_balance_amount": "77945.72"
   },
@@ -2542,7 +2542,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "389.73",
     "principal_amount": "809.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "809.37",
     "loan_balance_amount": "77136.35"
   },
@@ -2551,7 +2551,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "385.68",
     "principal_amount": "813.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "813.42",
     "loan_balance_amount": "76322.93"
   },
@@ -2560,7 +2560,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "381.61",
     "principal_amount": "817.49",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "817.49",
     "loan_balance_amount": "75505.44"
   },
@@ -2569,7 +2569,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "377.53",
     "principal_amount": "821.57",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "821.57",
     "loan_balance_amount": "74683.87"
   },
@@ -2578,7 +2578,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "373.42",
     "principal_amount": "825.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "825.68",
     "loan_balance_amount": "73858.19"
   },
@@ -2587,7 +2587,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "369.29",
     "principal_amount": "829.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "829.81",
     "loan_balance_amount": "73028.38"
   },
@@ -2596,7 +2596,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "365.14",
     "principal_amount": "833.96",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "833.96",
     "loan_balance_amount": "72194.42"
   },
@@ -2605,7 +2605,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "360.97",
     "principal_amount": "838.13",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "838.13",
     "loan_balance_amount": "71356.29"
   },
@@ -2614,7 +2614,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "333.00",
     "principal_amount": "866.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "866.10",
     "loan_balance_amount": "70490.19"
   },
@@ -2623,7 +2623,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "375.95",
     "principal_amount": "823.15",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "823.15",
     "loan_balance_amount": "69667.04"
   },
@@ -2632,7 +2632,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "348.34",
     "principal_amount": "850.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "850.76",
     "loan_balance_amount": "68816.28"
   },
@@ -2641,7 +2641,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "344.08",
     "principal_amount": "855.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "855.02",
     "loan_balance_amount": "67961.26"
   },
@@ -2650,7 +2650,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "339.81",
     "principal_amount": "859.29",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "859.29",
     "loan_balance_amount": "67101.97"
   },
@@ -2659,7 +2659,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "335.51",
     "principal_amount": "863.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "863.59",
     "loan_balance_amount": "66238.38"
   },
@@ -2668,7 +2668,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "331.19",
     "principal_amount": "867.91",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "867.91",
     "loan_balance_amount": "65370.47"
   },
@@ -2677,7 +2677,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "326.85",
     "principal_amount": "872.25",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "872.25",
     "loan_balance_amount": "64498.22"
   },
@@ -2686,7 +2686,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "322.49",
     "principal_amount": "876.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "876.61",
     "loan_balance_amount": "63621.61"
   },
@@ -2695,7 +2695,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "318.11",
     "principal_amount": "880.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "880.99",
     "loan_balance_amount": "62740.62"
   },
@@ -2704,7 +2704,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "313.70",
     "principal_amount": "885.40",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "885.40",
     "loan_balance_amount": "61855.22"
   },
@@ -2713,7 +2713,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "309.28",
     "principal_amount": "889.82",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "889.82",
     "loan_balance_amount": "60965.40"
   },
@@ -2722,7 +2722,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "284.51",
     "principal_amount": "914.59",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "914.59",
     "loan_balance_amount": "60050.81"
   },
@@ -2731,7 +2731,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "320.27",
     "principal_amount": "878.83",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "878.83",
     "loan_balance_amount": "59171.98"
   },
@@ -2740,7 +2740,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "295.86",
     "principal_amount": "903.24",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "903.24",
     "loan_balance_amount": "58268.74"
   },
@@ -2749,7 +2749,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "291.34",
     "principal_amount": "907.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "907.76",
     "loan_balance_amount": "57360.98"
   },
@@ -2758,7 +2758,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "286.80",
     "principal_amount": "912.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "912.30",
     "loan_balance_amount": "56448.68"
   },
@@ -2767,7 +2767,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "282.24",
     "principal_amount": "916.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "916.86",
     "loan_balance_amount": "55531.82"
   },
@@ -2776,7 +2776,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "277.66",
     "principal_amount": "921.44",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "921.44",
     "loan_balance_amount": "54610.38"
   },
@@ -2785,7 +2785,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "273.05",
     "principal_amount": "926.05",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "926.05",
     "loan_balance_amount": "53684.33"
   },
@@ -2794,7 +2794,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "268.42",
     "principal_amount": "930.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "930.68",
     "loan_balance_amount": "52753.65"
   },
@@ -2803,7 +2803,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "263.77",
     "principal_amount": "935.33",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "935.33",
     "loan_balance_amount": "51818.32"
   },
@@ -2812,7 +2812,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "259.09",
     "principal_amount": "940.01",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "940.01",
     "loan_balance_amount": "50878.31"
   },
@@ -2821,7 +2821,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "254.39",
     "principal_amount": "944.71",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "944.71",
     "loan_balance_amount": "49933.60"
   },
@@ -2830,7 +2830,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "241.35",
     "principal_amount": "957.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "957.75",
     "loan_balance_amount": "48975.85"
   },
@@ -2839,7 +2839,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "253.04",
     "principal_amount": "946.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "946.06",
     "loan_balance_amount": "48029.79"
   },
@@ -2848,7 +2848,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "240.15",
     "principal_amount": "958.95",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "958.95",
     "loan_balance_amount": "47070.84"
   },
@@ -2857,7 +2857,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "235.35",
     "principal_amount": "963.75",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "963.75",
     "loan_balance_amount": "46107.09"
   },
@@ -2866,7 +2866,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "230.54",
     "principal_amount": "968.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "968.56",
     "loan_balance_amount": "45138.53"
   },
@@ -2875,7 +2875,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "225.69",
     "principal_amount": "973.41",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "973.41",
     "loan_balance_amount": "44165.12"
   },
@@ -2884,7 +2884,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "220.83",
     "principal_amount": "978.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "978.27",
     "loan_balance_amount": "43186.85"
   },
@@ -2893,7 +2893,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "215.93",
     "principal_amount": "983.17",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "983.17",
     "loan_balance_amount": "42203.68"
   },
@@ -2902,7 +2902,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "211.02",
     "principal_amount": "988.08",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "988.08",
     "loan_balance_amount": "41215.60"
   },
@@ -2911,7 +2911,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "206.08",
     "principal_amount": "993.02",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "993.02",
     "loan_balance_amount": "40222.58"
   },
@@ -2920,7 +2920,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "201.11",
     "principal_amount": "997.99",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "997.99",
     "loan_balance_amount": "39224.59"
   },
@@ -2929,7 +2929,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "196.12",
     "principal_amount": "1002.98",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1002.98",
     "loan_balance_amount": "38221.61"
   },
@@ -2938,7 +2938,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "178.37",
     "principal_amount": "1020.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1020.73",
     "loan_balance_amount": "37200.88"
   },
@@ -2947,7 +2947,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "198.40",
     "principal_amount": "1000.70",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1000.70",
     "loan_balance_amount": "36200.18"
   },
@@ -2956,7 +2956,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "181.00",
     "principal_amount": "1018.10",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1018.10",
     "loan_balance_amount": "35182.08"
   },
@@ -2965,7 +2965,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "175.91",
     "principal_amount": "1023.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1023.19",
     "loan_balance_amount": "34158.89"
   },
@@ -2974,7 +2974,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "170.79",
     "principal_amount": "1028.31",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1028.31",
     "loan_balance_amount": "33130.58"
   },
@@ -2983,7 +2983,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "165.65",
     "principal_amount": "1033.45",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1033.45",
     "loan_balance_amount": "32097.13"
   },
@@ -2992,7 +2992,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "160.49",
     "principal_amount": "1038.61",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1038.61",
     "loan_balance_amount": "31058.52"
   },
@@ -3001,7 +3001,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "155.29",
     "principal_amount": "1043.81",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1043.81",
     "loan_balance_amount": "30014.71"
   },
@@ -3010,7 +3010,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "150.07",
     "principal_amount": "1049.03",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1049.03",
     "loan_balance_amount": "28965.68"
   },
@@ -3019,7 +3019,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "144.83",
     "principal_amount": "1054.27",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1054.27",
     "loan_balance_amount": "27911.41"
   },
@@ -3028,7 +3028,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "139.56",
     "principal_amount": "1059.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1059.54",
     "loan_balance_amount": "26851.87"
   },
@@ -3037,7 +3037,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "134.26",
     "principal_amount": "1064.84",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1064.84",
     "loan_balance_amount": "25787.03"
   },
@@ -3046,7 +3046,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "120.34",
     "principal_amount": "1078.76",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1078.76",
     "loan_balance_amount": "24708.27"
   },
@@ -3055,7 +3055,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "131.78",
     "principal_amount": "1067.32",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1067.32",
     "loan_balance_amount": "23640.95"
   },
@@ -3064,7 +3064,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "118.20",
     "principal_amount": "1080.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1080.90",
     "loan_balance_amount": "22560.05"
   },
@@ -3073,7 +3073,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "112.80",
     "principal_amount": "1086.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1086.30",
     "loan_balance_amount": "21473.75"
   },
@@ -3082,7 +3082,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "107.37",
     "principal_amount": "1091.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1091.73",
     "loan_balance_amount": "20382.02"
   },
@@ -3091,7 +3091,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "101.91",
     "principal_amount": "1097.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1097.19",
     "loan_balance_amount": "19284.83"
   },
@@ -3100,7 +3100,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "96.42",
     "principal_amount": "1102.68",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1102.68",
     "loan_balance_amount": "18182.15"
   },
@@ -3109,7 +3109,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "90.91",
     "principal_amount": "1108.19",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1108.19",
     "loan_balance_amount": "17073.96"
   },
@@ -3118,7 +3118,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "85.37",
     "principal_amount": "1113.73",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1113.73",
     "loan_balance_amount": "15960.23"
   },
@@ -3127,7 +3127,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "79.80",
     "principal_amount": "1119.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1119.30",
     "loan_balance_amount": "14840.93"
   },
@@ -3136,7 +3136,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "74.20",
     "principal_amount": "1124.90",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1124.90",
     "loan_balance_amount": "13716.03"
   },
@@ -3145,7 +3145,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "68.58",
     "principal_amount": "1130.52",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1130.52",
     "loan_balance_amount": "12585.51"
   },
@@ -3154,7 +3154,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "58.73",
     "principal_amount": "1140.37",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1140.37",
     "loan_balance_amount": "11445.14"
   },
@@ -3163,7 +3163,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "61.04",
     "principal_amount": "1138.06",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1138.06",
     "loan_balance_amount": "10307.08"
   },
@@ -3172,7 +3172,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "51.54",
     "principal_amount": "1147.56",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1147.56",
     "loan_balance_amount": "9159.52"
   },
@@ -3181,7 +3181,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "45.80",
     "principal_amount": "1153.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1153.30",
     "loan_balance_amount": "8006.22"
   },
@@ -3190,7 +3190,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "40.03",
     "principal_amount": "1159.07",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1159.07",
     "loan_balance_amount": "6847.15"
   },
@@ -3199,7 +3199,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "34.24",
     "principal_amount": "1164.86",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1164.86",
     "loan_balance_amount": "5682.29"
   },
@@ -3208,7 +3208,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "28.41",
     "principal_amount": "1170.69",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1170.69",
     "loan_balance_amount": "4511.60"
   },
@@ -3217,7 +3217,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "22.56",
     "principal_amount": "1176.54",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1176.54",
     "loan_balance_amount": "3335.06"
   },
@@ -3226,7 +3226,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "16.68",
     "principal_amount": "1182.42",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1182.42",
     "loan_balance_amount": "2152.64"
   },
@@ -3235,7 +3235,7 @@
     "payment_amount": "1199.10",
     "interest_amount": "10.76",
     "principal_amount": "1188.34",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "1188.34",
     "loan_balance_amount": "964.30"
   },
@@ -3244,7 +3244,7 @@
     "payment_amount": "969.12",
     "interest_amount": "4.82",
     "principal_amount": "964.30",
-    "special_principal_amount": "0",
+    "special_principal_amount": "0.00",
     "total_principal_amount": "964.30",
     "loan_balance_amount": "0.00"
   }


### PR DESCRIPTION
This commit fixes a bug in the interest calculation logic that occurred when a special payment was made on an irregular date.

The previous implementation calculated interest for sub-periods independently, which led to incorrect results for non-additive day count conventions like '30/360'.

The new implementation refactors the interest calculation into a new private method, `_calculate_interest_for_period`. This method correctly prorates the total days of an interest period among the sub-periods created by special payments, ensuring the interest is calculated accurately based on the correct number of days and the outstanding balance for each sub-period.

A regression test has been added to verify the fix.